### PR TITLE
Remove "maxConnections" config

### DIFF
--- a/src/main/java/com/eighthlight/fabrial/server/ServerConfig.java
+++ b/src/main/java/com/eighthlight/fabrial/server/ServerConfig.java
@@ -2,24 +2,21 @@ package com.eighthlight.fabrial.server;
 
 public class ServerConfig {
   public final int port;
-  public final int maxConnections;
   public final int readTimeout;
 
   public static final int DEFAULT_PORT = 8080;
-  public static final int DEFAULT_MAX_CONNECTIONS = 50;
   public static final int DEFAULT_READ_TIMEOUT = 10000;
 
   public ServerConfig() {
-    this(DEFAULT_PORT, DEFAULT_MAX_CONNECTIONS, DEFAULT_READ_TIMEOUT);
+    this(DEFAULT_PORT, DEFAULT_READ_TIMEOUT);
   }
 
   public ServerConfig(int port) {
-    this(port, DEFAULT_MAX_CONNECTIONS, DEFAULT_READ_TIMEOUT);
+    this(port, DEFAULT_READ_TIMEOUT);
   }
 
-  public ServerConfig(int port, int maxConnections, int readTimeout) {
+  public ServerConfig(int port, int readTimeout) {
     this.port = port;
-    this.maxConnections = maxConnections;
     this.readTimeout = readTimeout;
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
+++ b/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
@@ -33,7 +33,7 @@ public class TcpServer implements Closeable {
     this.serverSocket = Optional.empty();
     this.acceptThread = Optional.empty();
     this.connectionCount = new AtomicInteger(0);
-    this.connectionHandlerExecutor = Executors.newFixedThreadPool(this.config.maxConnections);
+    this.connectionHandlerExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
   }
 
   public int getConnectionCount() {
@@ -49,7 +49,7 @@ public class TcpServer implements Closeable {
    */
   public void start() throws IOException {
     assert !serverSocket.isPresent();
-    ServerSocket socket = new ServerSocket(this.config.port, this.config.maxConnections);
+    ServerSocket socket = new ServerSocket(this.config.port);
     logger.info("Server started on " + this.config.port);
     this.serverSocket = Optional.of(socket);
     Thread acceptThread = new Thread(this::acceptConnections);

--- a/src/test/java/com/eighthlight/fabrial/test/server/ServerConfigTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/ServerConfigTest.java
@@ -18,6 +18,5 @@ class ServerConfigTest {
     int port = 81;
     ServerConfig conf = new ServerConfig(port);
     assertThat(conf.port, equalTo(port));
-    assertThat(conf.maxConnections, equalTo(ServerConfig.DEFAULT_MAX_CONNECTIONS));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/server/TcpServerIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/TcpServerIntegrationTest.java
@@ -8,11 +8,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TcpServerIntegrationTest {
@@ -21,11 +23,10 @@ public class TcpServerIntegrationTest {
 
   @BeforeEach
   void setUp() {
-    client = new TcpClient(new InetSocketAddress(8080));
     // shorten read timeout for testing connection closures due to the socket being idle
     server = new TcpServer(new ServerConfig(8080,
-                                            ServerConfig.DEFAULT_MAX_CONNECTIONS,
                                             50));
+    client = new TcpClient(new InetSocketAddress(server.config.port));
   }
 
   @AfterEach
@@ -65,7 +66,7 @@ public class TcpServerIntegrationTest {
     server.start();
     client.connect();
     assertThat(() -> server.getConnectionCount(), eventuallyEval(is(1)));
-    TcpClient secondClient = new TcpClient(new InetSocketAddress(8080));
+    TcpClient secondClient = new TcpClient(new InetSocketAddress(server.config.port));
     secondClient.connect();
     assertThat(() -> server.getConnectionCount(), eventuallyEval(is(2)));
     client.close();


### PR DESCRIPTION
Turns out, that's not what ServerSocket's backlog property does. It's
the kernel's backlog of connections waiting to be `accept`ed by the
server. Instead, just setting using the default `backlog`.

However, this means we're also not tieing the # of threads in the pool
to the max connections. Instead, we're using the number of
"availableProcessors" according to the runtime.