### PR TITLE
Add directory option to command-line interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,9 @@ dependencies {
 
     testCompile('org.hamcrest:hamcrest-junit:2.0.0.0')
     testCompile('com.github.grantwest.eventually:hamcrest-eventually-matchers:0.0.1')
-    testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
+    testCompile('org.junit.jupiter:junit-jupiter-api:5.3.0')
+    testCompile('org.junit.jupiter:junit-jupiter-params:5.3.0')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.0')
 }
 
 test {
@@ -39,8 +40,6 @@ test {
     }
 
 }
-
-
 
 mainClassName = 'com.eighthlight.fabrial.App'
 jar {

--- a/src/main/java/com/eighthlight/fabrial/App.java
+++ b/src/main/java/com/eighthlight/fabrial/App.java
@@ -45,7 +45,7 @@ public class App {
       String pathString = ns.getString("directory");
       Path directoryPath;
       try {
-        directoryPath = Paths.get(pathString);
+        directoryPath = Paths.get(pathString).toAbsolutePath();
       } catch (InvalidPathException e) {
         throw new ArgumentParserException("\"" + pathString + "\" is not a valid path",
                                           e,

--- a/src/main/java/com/eighthlight/fabrial/App.java
+++ b/src/main/java/com/eighthlight/fabrial/App.java
@@ -8,6 +8,9 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -25,6 +28,12 @@ public class App {
           .setDefault(ServerConfig.DEFAULT_PORT)
           .dest("port")
           .help("A port number between 0-65535. Specifying 0 will cause the server to listen on a random port.");
+
+    parser.addArgument("-d")
+          .setDefault(ServerConfig.DEFAULT_DIRECTORY_PATH.toString())
+          .dest("directory")
+          .help("Directory that files should be served from. Defaults to current working directory.");
+
     try {
       Namespace ns = parser.parseArgs(args);
 
@@ -33,7 +42,19 @@ public class App {
         throw new ArgumentParserException("port must be between 0-65535", parser);
       }
 
-      return Optional.of(new ServerConfig(port));
+      String pathString = ns.getString("directory");
+      Path directoryPath;
+      try {
+        directoryPath = Paths.get(pathString);
+      } catch (InvalidPathException e) {
+        throw new ArgumentParserException("\"" + pathString + "\" is not a valid path",
+                                          e,
+                                          parser);
+      }
+
+      return Optional.of(new ServerConfig(port,
+                                          ServerConfig.DEFAULT_READ_TIMEOUT,
+                                          directoryPath));
     } catch (ArgumentParserException e) {
       parser.handleError(e);
       return Optional.empty();

--- a/src/main/java/com/eighthlight/fabrial/server/ServerConfig.java
+++ b/src/main/java/com/eighthlight/fabrial/server/ServerConfig.java
@@ -1,22 +1,20 @@
 package com.eighthlight.fabrial.server;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 public class ServerConfig {
   public final int port;
   public final int readTimeout;
+  public final Path directoryPath;
 
   public static final int DEFAULT_PORT = 8080;
   public static final int DEFAULT_READ_TIMEOUT = 10000;
+  public static final Path DEFAULT_DIRECTORY_PATH = Paths.get("").toAbsolutePath();
 
-  public ServerConfig() {
-    this(DEFAULT_PORT, DEFAULT_READ_TIMEOUT);
-  }
-
-  public ServerConfig(int port) {
-    this(port, DEFAULT_READ_TIMEOUT);
-  }
-
-  public ServerConfig(int port, int readTimeout) {
+  public ServerConfig(int port, int readTimeout, Path directoryPath) {
     this.port = port;
     this.readTimeout = readTimeout;
+    this.directoryPath = directoryPath;
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
+++ b/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
@@ -59,8 +59,9 @@ public class TcpServer implements Closeable {
    */
   public void start() throws IOException {
     assert !serverSocket.isPresent();
-    ServerSocket socket = new ServerSocket(this.config.port);
-    logger.info("Server started on " + this.config.port);
+    ServerSocket socket = new ServerSocket(config.port);
+    logger.info("Server started on " + config.port);
+    logger.info("Serving files from " + config.directoryPath);
     this.serverSocket = Optional.of(socket);
     Thread acceptThread = new Thread(this::acceptConnections);
     this.acceptThread = Optional.of(acceptThread);

--- a/src/test/java/com/eighthlight/fabrial/test/args/ArgParserDirectoryIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/args/ArgParserDirectoryIntegrationTest.java
@@ -32,4 +32,11 @@ public class ArgParserDirectoryIntegrationTest {
     ServerConfig config = parseConfig(args).get();
     assertThat(config.directoryPath, equalTo(ServerConfig.DEFAULT_DIRECTORY_PATH));
   }
+
+  @Test
+  void expandsRelativePaths() {
+    String[] args = List.of("-d", "foo").toArray(new String[0]);
+    ServerConfig config = parseConfig(args).get();
+    assertThat(config.directoryPath, equalTo(Paths.get("foo").toAbsolutePath()));
+  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/args/ArgParserDirectoryIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/args/ArgParserDirectoryIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.eighthlight.fabrial.test.args;
+
+import com.eighthlight.fabrial.server.ServerConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static com.eighthlight.fabrial.App.parseConfig;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ArgParserDirectoryIntegrationTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/", "/var", "/foo/bar/baz"})
+  void parsesValidDirectories(String dirString) {
+    Path dir = Paths.get(dirString);
+
+    String[] args = List.of("-d", dirString).toArray(new String[0]);
+    ServerConfig config = parseConfig(args).get();
+    assertThat(config.port, equalTo(ServerConfig.DEFAULT_PORT));
+    assertThat(config.directoryPath, equalTo(dir));
+  }
+
+  @Test
+  void usesDefaultDirWhenUnspecified() {
+    String[] args = List.of().toArray(new String[0]);
+    ServerConfig config = parseConfig(args).get();
+    assertThat(config.directoryPath, equalTo(ServerConfig.DEFAULT_DIRECTORY_PATH));
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/args/ArgParserPortIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/args/ArgParserPortIntegrationTest.java
@@ -10,7 +10,7 @@ import static com.eighthlight.fabrial.App.parseConfig;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ArgParserIntegrationTest {
+public class ArgParserPortIntegrationTest {
   @Test
   void emptyArgsYieldsDefaultConfig() {
     String[] args = List.of().toArray(new String[0]);

--- a/src/test/java/com/eighthlight/fabrial/test/server/ServerConfigTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/ServerConfigTest.java
@@ -8,15 +8,11 @@ import static org.hamcrest.Matchers.equalTo;
 
 class ServerConfigTest {
   @Test
-  void defaultPort() {
-    ServerConfig conf = new ServerConfig();
-    assertThat(conf.port, equalTo(ServerConfig.DEFAULT_PORT));
-  }
-
-  @Test
   void customPort() {
     int port = 81;
-    ServerConfig conf = new ServerConfig(port);
+    ServerConfig conf = new ServerConfig(port,
+                                         ServerConfig.DEFAULT_READ_TIMEOUT,
+                                         ServerConfig.DEFAULT_DIRECTORY_PATH);
     assertThat(conf.port, equalTo(port));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/server/TcpServerIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/TcpServerIntegrationTest.java
@@ -18,7 +18,7 @@ public class TcpServerIntegrationTest {
   @BeforeEach
   void setUp() {
     // shorten read timeout for testing connection closures due to the socket being idle
-    server = new TcpServer(new ServerConfig(8080, 50));
+    server = new TcpServer(new ServerConfig(8080, 50, ServerConfig.DEFAULT_DIRECTORY_PATH));
     client = new TcpClient(new InetSocketAddress(server.config.port));
   }
 


### PR DESCRIPTION
Resolves #14

Example help text:
```
java -jar ./build/libs/fabrial-all-1.0-SNAPSHOT.jar -h
usage: fabrial [-h] [-p PORT] [-d DIRECTORY]

Minimal HTTP file server.

named arguments:
  -h, --help             show this help message and exit
  -p PORT                A port number between 0-65535. Specifying 0 will cause the server to listen on a random port.
  -d DIRECTORY           Directory that files should be served from. Defaults to current working directory.
```

Usage:
```
 java -jar ./build/libs/fabrial-all-1.0-SNAPSHOT.jar -d public
Sep 04, 2018 3:21:45 PM com.eighthlight.fabrial.server.TcpServer start
INFO: Server started on 8080
Sep 04, 2018 3:21:45 PM com.eighthlight.fabrial.server.TcpServer start
INFO: Serving files from /Users/briangerstle/Code/fabrial/public
```