### PR TITLE
Implement message body serialization

### DIFF
--- a/src/main/java/com/eighthlight/fabrial/http/response/HttpHeaderWriter.java
+++ b/src/main/java/com/eighthlight/fabrial/http/response/HttpHeaderWriter.java
@@ -46,8 +46,6 @@ public class HttpHeaderWriter {
     os.write(": ");
     // field-value
     os.write(value);
-    // OWS
-    os.write(" ");
     // CRLF (part of HTTP message)
     os.write(CRLF);
     os.flush();

--- a/src/main/java/com/eighthlight/fabrial/http/response/Response.java
+++ b/src/main/java/com/eighthlight/fabrial/http/response/Response.java
@@ -2,6 +2,7 @@ package com.eighthlight.fabrial.http.response;
 
 import com.eighthlight.fabrial.http.HttpVersion;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
@@ -12,6 +13,7 @@ public class Response {
   public final int statusCode;
   public final String reason;
   public final Map<String, String> headers;
+  public final InputStream body;
 
   /**
    * Initialize a response object.
@@ -19,12 +21,18 @@ public class Response {
    * @param statusCode  Status code [100-999].
    * @param reason      Reason explaining the response (can be @code null).
    * @param headers     Map of response headers (can be @code null).
+   * @param body        Stream of bytes to be sent as the body of the message (can be @code null).
    */
-  public Response(String version, int statusCode, String reason, Map<String, String> headers) {
+  public Response(String version,
+                  int statusCode,
+                  String reason,
+                  Map<String, String> headers,
+                  InputStream body) {
     this.version = Objects.requireNonNull(version);
     this.statusCode = statusCode;
     this.reason = reason;
     this.headers = Optional.ofNullable(headers).map(Map::copyOf).orElse(Map.of());
+    this.body = body;
 
     if (!HttpVersion.allVersions.contains(this.version)) {
       throw new IllegalArgumentException(
@@ -55,12 +63,13 @@ public class Response {
     return statusCode == response.statusCode &&
            Objects.equals(version, response.version) &&
            Objects.equals(reason, response.reason) &&
-           Objects.equals(headers, response.headers);
+           Objects.equals(headers, response.headers) &&
+           Objects.equals(body, response.body);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, statusCode, reason, headers);
+    return Objects.hash(version, statusCode, reason, headers, body);
   }
 
   @Override
@@ -70,6 +79,7 @@ public class Response {
            ", statusCode=" + statusCode +
            ", reason='" + reason + '\'' +
            ", headers=" + headers +
+           ", body=" + body +
            '}';
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/response/ResponseBuilder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/response/ResponseBuilder.java
@@ -1,5 +1,7 @@
 package com.eighthlight.fabrial.http.response;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -12,6 +14,7 @@ public class ResponseBuilder {
   private int statusCode;
   private String reason;
   private HashMap<String, String> headers;
+  private InputStream body;
 
   public ResponseBuilder() {
     headers = new HashMap<String, String>();
@@ -42,7 +45,17 @@ public class ResponseBuilder {
     return this;
   }
 
+  public ResponseBuilder withBodyFromString(String bodyStr) {
+    this.body = new ByteArrayInputStream(bodyStr.getBytes());
+    return this;
+  }
+
+  public ResponseBuilder withBody(InputStream os) {
+    this.body = os;
+    return this;
+  }
+
   public Response build() {
-    return new Response(version, statusCode, reason, headers, null);
+    return new Response(version, statusCode, reason, headers, body);
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/response/ResponseBuilder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/response/ResponseBuilder.java
@@ -43,6 +43,6 @@ public class ResponseBuilder {
   }
 
   public Response build() {
-    return new Response(version, statusCode, reason, headers);
+    return new Response(version, statusCode, reason, headers, null);
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/response/ResponseWriter.java
+++ b/src/main/java/com/eighthlight/fabrial/http/response/ResponseWriter.java
@@ -31,5 +31,9 @@ public class ResponseWriter {
       writer.write(CRLF);
     }
     writer.flush();
+    if (response.body != null) {
+      response.body.transferTo(os);
+      os.flush();
+    }
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderWriterSerializationTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderWriterSerializationTests.java
@@ -19,7 +19,7 @@ public class HttpHeaderWriterSerializationTests {
     try (var os = new ByteArrayOutputStream()) {
       var writer = new HttpHeaderWriter(os);
       writer.writeFields(Map.of("Allow", "GET"));
-      assertThat(os.toString(), is("Allow: GET " + CRLF));
+      assertThat(os.toString(), is("Allow: GET" + CRLF));
     }
   }
 
@@ -28,18 +28,17 @@ public class HttpHeaderWriterSerializationTests {
     try (var os = new ByteArrayOutputStream()) {
       var writer = new HttpHeaderWriter(os);
       writer.writeFields(Map.of("Allow", "GET,HEAD,OPTIONS"));
-      assertThat(os.toString(), is("Allow: GET,HEAD,OPTIONS " + CRLF));
+      assertThat(os.toString(), is("Allow: GET,HEAD,OPTIONS" + CRLF));
     }
   }
 
   @Test
   void writeMultipleFields() throws IOException {
     try (var os = new ByteArrayOutputStream()) {
-      var writer  new HttpHeaderWriter(os);
+      var writer = new HttpHeaderWriter(os);
       writer.writeFields(Map.of(
           "Allow", "GET,HEAD,OPTIONS",
           "Content-Length", "0"));
-      var expectedAllow = "Allow: GET,HEAD,OPTIONS ";
       var expectedAllow = "Allow: GET,HEAD,OPTIONS";
       var expectedContentLength = "Content-Length: 0";
       var headerLines = Arrays.asList(os.toString().split(CRLF));

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderWriterSerializationTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderWriterSerializationTests.java
@@ -35,12 +35,13 @@ public class HttpHeaderWriterSerializationTests {
   @Test
   void writeMultipleFields() throws IOException {
     try (var os = new ByteArrayOutputStream()) {
-      var writer = new HttpHeaderWriter(os);
+      var writer  new HttpHeaderWriter(os);
       writer.writeFields(Map.of(
           "Allow", "GET,HEAD,OPTIONS",
           "Content-Length", "0"));
       var expectedAllow = "Allow: GET,HEAD,OPTIONS ";
-      var expectedContentLength = "Content-Length: 0 ";
+      var expectedAllow = "Allow: GET,HEAD,OPTIONS";
+      var expectedContentLength = "Content-Length: 0";
       var headerLines = Arrays.asList(os.toString().split(CRLF));
       assertThat(headerLines, containsInAnyOrder(expectedAllow, expectedContentLength));
     }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpResponseHeaderSerializationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpResponseHeaderSerializationTest.java
@@ -29,7 +29,7 @@ public class HttpResponseHeaderSerializationTest {
   @Test
   void serializesOneHeader() throws IOException {
     var responseStr = serializeHeaders(Map.of("Allow", "HEAD,OPTIONS"));
-    assertThat(responseStr , is("Allow: HEAD,OPTIONS " + CRLF));
+    assertThat(responseStr , is("Allow: HEAD,OPTIONS" + CRLF));
   }
 
   @Test
@@ -40,7 +40,7 @@ public class HttpResponseHeaderSerializationTest {
                                     "Content-Length", "0"))
                 .split(CRLF));
     assertThat(headerLines,
-               containsInAnyOrder("Allow: HEAD,OPTIONS ", "Content-Length: 0 "));
+               containsInAnyOrder("Allow: HEAD,OPTIONS", "Content-Length: 0"));
   }
 
   @Test
@@ -53,7 +53,7 @@ public class HttpResponseHeaderSerializationTest {
                                   .orElseAssert();;
           headers.entrySet()
                  .stream()
-                 .map(e -> e.getKey() + ": " + e.getValue() + " ")
+                 .map(e -> e.getKey() + ": " + e.getValue())
                  .forEach(s -> assertThat(headerLines, hasItem(s)));
         });
   }

--- a/src/test/java/com/eighthlight/fabrial/test/http/ResponseWriterTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ResponseWriterTests.java
@@ -4,53 +4,86 @@ import com.eighthlight.fabrial.http.response.Response;
 import com.eighthlight.fabrial.http.response.ResponseWriter;
 import com.eighthlight.fabrial.utils.Result;
 import org.junit.jupiter.api.Test;
+import org.quicktheories.core.Gen;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 import static com.eighthlight.fabrial.test.gen.ArbitraryStrings.alphanumeric;
 import static com.eighthlight.fabrial.test.http.ArbitraryHttp.*;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.maps;
+import static org.quicktheories.generators.SourceDSL.strings;
 
 public class ResponseWriterTests {
+  private static Gen<ByteArrayInputStream> bodyStreams(int length) {
+    return strings()
+        .allPossible()
+        .ofLengthBetween(1, length)
+        .map(s -> {
+          return Result.attempt(() ->
+                                    new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8))
+          ).orElseAssert();
+        });
+  }
+
+  private static Gen<Response> responses() {
+    return httpVersions()
+        .zip(statusCodes(),
+             responseReasons(10).toOptionals(20),
+             maps().of(alphanumeric(16), alphanumeric(16))
+                   .ofSizeBetween(1, 5).toOptionals(50),
+             bodyStreams(10).toOptionals(10),
+             (version, statusCode, reason, headers, body) -> {
+               return new Response(version,
+                                   statusCode,
+                                   reason.orElse(null),
+                                   headers.orElse(null),
+                                   body.orElse(null));
+             });
+  }
   @Test
   void arbitraryResponseSerialization() {
-    qt().forAll(httpVersions(),
-                statusCodes(),
-                responseReasons(10),
-                maps().of(alphanumeric(16), alphanumeric(16))
-                      .ofSizeBetween(1, 5))
-        .checkAssert((version, statusCode, reason, headerFields) -> {
-          var response = new Response(version,
-                                      statusCode,
-                                      reason,
-                                      headerFields);
-          try (var os = new ByteArrayOutputStream()) {
-            Result.attempt(() -> new ResponseWriter(os).writeResponse(response)).orElseAssert();
-            var responseLines = os.toString().split(CRLF);
-            assertThat(responseLines[0],
-                       is("HTTP/"
-                          + version
-                          + " "
-                          + statusCode
-                          + " "
-                          + reason));
-            List<String> otherLines =
-                Arrays.asList(responseLines).subList(1, responseLines.length);
-            headerFields.entrySet()
+    qt().forAll(responses()).checkAssert((response) -> {
+      try (var os = new ByteArrayOutputStream()) {
+        Result.attempt(() -> new ResponseWriter(os).writeResponse(response)).orElseAssert();
+        var responseLines = os.toString().split(CRLF);
+        assertThat(responseLines[0],
+                   is("HTTP/"
+                      + response.version
+                      + " "
+                      + response.statusCode
+                      + " "
+                      + Optional.ofNullable(response.reason).orElse("")));
+
+        if (response.headers == null && response.body == null) {
+          assertThat(responseLines.length, equalTo(1));
+          return;
+        }
+
+        List<String> otherLines =
+            Arrays.asList(responseLines).subList(1, responseLines.length);
+
+        List<String> headerLines = otherLines.subList(0, response.headers.size());
+
+        assertThat(headerLines.isEmpty(), equalTo(response.headers.isEmpty()));
+        response.headers.entrySet()
                         .stream()
                         .map(e -> e.getKey() + ": " + e.getValue() + " ")
-                        .forEach(s -> assertThat(otherLines, hasItem(s)));
-          } catch (IOException e) {
-            throw new AssertionError(e);
-          }
-        });
+                        .forEach(s -> assertThat(headerLines, hasItem(s)));
+      } catch (IOException e) {
+        throw new AssertionError(e);
+      }
+    });
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/ResponseWriterTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ResponseWriterTests.java
@@ -22,6 +22,7 @@ import static com.eighthlight.fabrial.test.http.ArbitraryHttp.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.maps;
@@ -125,7 +126,7 @@ public class ResponseWriterTests {
         assertThat(headerLines.isEmpty(), equalTo(response.headers.isEmpty()));
         response.headers.entrySet()
                         .stream()
-                        .map(e -> e.getKey() + ": " + e.getValue() + " ")
+                        .map(e -> e.getKey() + ": " + e.getValue())
                         .forEach(s -> assertThat(headerLines, hasItem(s)));
 
         List<String> bodyLines = otherLines.subList(response.headers.size(), otherLines.size());

--- a/src/test/java/com/eighthlight/fabrial/test/http/ResponseWriterTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ResponseWriterTests.java
@@ -100,6 +100,34 @@ public class ResponseWriterTests {
   }
 
   @Test
+  void responseWithHeadersAndBody() throws IOException {
+    var os = new ByteArrayOutputStream();
+    var response = new ResponseBuilder()
+        .withStatusCode(200)
+        .withVersion(HttpVersion.ONE_ONE)
+        .withHeader("Content-Length", "3")
+        .withBodyFromString("foo")
+        .build();
+    new ResponseWriter(os).writeResponse(response);
+    var responseLines = os.toString().split(CRLF);
+    assertThat(responseLines.length, is(4));
+    assertThat(responseLines[0],
+               is("HTTP/"
+                  + response.version
+                  + " "
+                  + response.statusCode
+                  + " "
+                  + Optional.ofNullable(response.reason).orElse("")));
+    assertThat(responseLines[1],
+               is("Content-Length: 3"));
+    // must have an extra empty line between headers & body
+    assertThat(responseLines[2], is(""));
+    assertThat(responseLines[3],
+               is("foo"));
+    os.close();
+  }
+
+  @Test
   void arbitraryResponseSerialization() {
     qt().forAll(responses()).checkAssert((response) -> {
       try (var os = new ByteArrayOutputStream()) {


### PR DESCRIPTION
Bodies are considered any stream that can be read from, which is added to the message by transferring it to the output stream where the message is being sent.