### PR TITLE
Implement directory listing for GET request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ jdk:
   - oraclejdk10
 script:
   - ./gradlew check -i
-  - ./gradlew testAcceptance -i
+  - ./gradlew clean testAcceptance -i

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ task testAcceptance(dependsOn: 'jar', type: Test) {
 
     useJUnitPlatform {
         includeTags 'acceptance'
+        includeEngines 'junit-jupiter'
     }
 }
 testAcceptance.dependsOn tasks.fatJar

--- a/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
+++ b/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
@@ -46,7 +46,7 @@ public class HttpConnectionHandler implements ConnectionHandler {
           );
       return;
     }
-    logger.trace("Handling request {}", StructuredArguments.kv("request", request));
+    logger.info("Handling request {}", StructuredArguments.kv("request", request));
     Response response = responseTo(request);
     logger.info("Writing response {}", StructuredArguments.kv("response", response));
     new ResponseWriter(os).writeResponse(response);

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -17,6 +17,10 @@ public class FileHttpResponder implements HttpResponder {
 
   public static interface DataSource {
     public boolean fileExistsAtPath(Path path);
+
+    public boolean isDirectory(Path path);
+
+    public List<String> getDirectoryContents(Path path);
   }
 
   public FileHttpResponder(DataSource dataSource) {

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -60,13 +60,18 @@ public class FileHttpResponder implements HttpResponder {
                         .map(p -> p.getFileName().toString())
                         .reduce((p1, p2) -> p1 + "," + p2)
                         .orElse("");
+          if (contents.isEmpty()) {
+            return builder.withHeader("Content-Length", "0")
+                          .withStatusCode(200)
+                          .build();
+          }
           var charset = StandardCharsets.UTF_8;
           var contentBytes = contents.getBytes(charset);
           return builder.withStatusCode(200)
-              .withHeader("Content-Type", "text/plain; charset=" + charset.name().toLowerCase())
-              .withHeader("Content-Length", Integer.toString(contentBytes.length))
-              .withBody(new ByteArrayInputStream(contentBytes))
-              .build();
+                        .withHeader("Content-Length", Integer.toString(contentBytes.length))
+                        .withHeader("Content-Type", "text/plain; charset=" + charset.name().toLowerCase())
+                        .withBody(new ByteArrayInputStream(contentBytes))
+                        .build();
         } else {
           return builder.withStatusCode(501).withReason("coming soon!").build();
         }

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -20,7 +20,7 @@ public class FileHttpResponder implements HttpResponder {
 
     public boolean isDirectory(Path path);
 
-    public List<String> getDirectoryContents(Path path);
+    public List<Path> getDirectoryContents(Path path);
   }
 
   public FileHttpResponder(DataSource dataSource) {

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
@@ -2,6 +2,7 @@ package com.eighthlight.fabrial.http.file;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 
 public class FileResponderDataSourceImpl implements FileHttpResponder.DataSource {
@@ -16,5 +17,15 @@ public class FileResponderDataSourceImpl implements FileHttpResponder.DataSource
     return Paths.get(baseDirPath.toAbsolutePath().toString(), path.toString())
                 .toFile()
                 .exists();
+  }
+
+  @Override
+  public boolean isDirectory(Path path) {
+    return false;
+  }
+
+  @Override
+  public List<String> getDirectoryContents(Path path) {
+    return null;
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
@@ -1,7 +1,9 @@
 package com.eighthlight.fabrial.http.file;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,19 +14,28 @@ public class FileResponderDataSourceImpl implements FileHttpResponder.DataSource
     this.baseDirPath = Optional.ofNullable(baseDirPath).orElse(Paths.get("."));
   }
 
+  private Path absolutePathInBaseDir(Path path) {
+    return Paths.get(baseDirPath.toAbsolutePath().toString(), path.toString());
+  }
+
   @Override
   public boolean fileExistsAtPath(Path path) {
-    return Paths.get(baseDirPath.toAbsolutePath().toString(), path.toString())
-                .toFile()
-                .exists();
+    return absolutePathInBaseDir(path).toFile().exists();
   }
 
   @Override
   public boolean isDirectory(Path path) {
-    return false;
+    return absolutePathInBaseDir(path).toFile().isDirectory();
   }
 
   @Override
   public List<Path> getDirectoryContents(Path path) {
+    return Arrays.asList(
+        Arrays.asList(absolutePathInBaseDir(path).toFile().listFiles())
+              .stream()
+              .map(File::getPath)
+              .map(Paths::get)
+              .map(baseDirPath::relativize)
+              .toArray(Path[]::new));
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
@@ -30,12 +30,15 @@ public class FileResponderDataSourceImpl implements FileHttpResponder.DataSource
 
   @Override
   public List<Path> getDirectoryContents(Path path) {
-    return Arrays.asList(
-        Arrays.asList(absolutePathInBaseDir(path).toFile().listFiles())
-              .stream()
-              .map(File::getPath)
-              .map(Paths::get)
-              .map(baseDirPath::relativize)
-              .toArray(Path[]::new));
+    return Optional
+        .ofNullable(absolutePathInBaseDir(path).toFile().listFiles())
+        .map(Arrays::asList)
+        .map(List::stream)
+        .map(s -> s.map(File::getPath)
+                   .map(Paths::get)
+                   .map(baseDirPath::relativize)
+                   .toArray(Path[]::new))
+        .map(Arrays::asList)
+        .orElse(null);
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
@@ -25,7 +25,6 @@ public class FileResponderDataSourceImpl implements FileHttpResponder.DataSource
   }
 
   @Override
-  public List<String> getDirectoryContents(Path path) {
-    return null;
+  public List<Path> getDirectoryContents(Path path) {
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
@@ -53,7 +53,7 @@ public class FileHttpResponderTest {
       }
 
       @Override
-      public List<String> getDirectoryContents(Path path) {
+      public List<Path> getDirectoryContents(Path path) {
         return List.of();
       }
     });

--- a/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
@@ -46,8 +46,19 @@ public class FileHttpResponderTest {
       public boolean fileExistsAtPath(Path path) {
         return files.contains(path);
       }
+
+      @Override
+      public boolean isDirectory(Path path) {
+        return false;
+      }
+
+      @Override
+      public List<String> getDirectoryContents(Path path) {
+        return List.of();
+      }
     });
   }
+
 
   @Test
   void responds200ToHeadForExistingFiles() {

--- a/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
@@ -190,4 +190,22 @@ public class FileHttpResponderTest {
                           Integer.toString(bodyString.getBytes(StandardCharsets.UTF_8).length)));
     }
   }
+
+  @Test
+  void getEmptyDirectoryResponseBodyIsEmpty() throws IOException {
+    try (var tmpDirFixture = new TempDirectoryFixture();) {
+      var responder = new FileHttpResponder(
+          new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath));
+      var response = responder.getResponse(
+          new RequestBuilder()
+              .withVersion(HttpVersion.ONE_ONE)
+              .withMethod(Method.GET)
+              .withUriString("/")
+              .build());
+      assertThat(response.statusCode, is(200));
+      assertThat(response.headers, not(hasKey("Content-Type")));
+      assertThat(response.headers, hasEntry("Content-Length", "0"));
+      assertThat(response.body, is(nullValue()));
+    }
+  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -35,7 +36,7 @@ public class FileResponderDataSourceImplIntegrationTest {
           new FileResponderDataSourceImpl(tmpFileFixture.tempFilePath.getParent().toAbsolutePath());
 
       assertThat(dataSource.getDirectoryContents(tmpFileFixture.tempFilePath.getFileName()),
-                 equalTo(nullValue()));
+                 is(nullValue()));
     }
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
@@ -52,9 +52,9 @@ public class FileResponderDataSourceImplIntegrationTest {
           new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath);
 
       assertThat(dataSource.getDirectoryContents(Paths.get("/")),
-                 containsInAnyOrder(List.of(
+                 containsInAnyOrder(
                      tmpFileFixture1.tempFilePath.getFileName(),
-                     tmpFileFixture2.tempFilePath.getFileName())));
+                     tmpFileFixture2.tempFilePath.getFileName()));
     }
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
@@ -1,0 +1,26 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.file.FileResponderDataSourceImpl;
+import com.eighthlight.fabrial.test.file.TempDirectoryFixture;
+import com.eighthlight.fabrial.test.file.TempFileFixture;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FileResponderDataSourceImplIntegrationTest {
+  @Test
+  void respondsWithDirectoryContents() {
+    try (var tmpDirFixture = new TempDirectoryFixture();
+         var tmpFileFixture = new TempFileFixture(tmpDirFixture.tempDirPath)) {
+      var dataSource = new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath);
+
+      assertThat(dataSource.fileExistsAtPath(tmpDirFixture.tempDirPath), equalTo(true));
+
+      assertThat(dataSource.isDirectory(tmpDirFixture.tempDirPath), equalTo(true));
+
+      assertThat(dataSource.getDirectoryContents(tmpDirFixture.tempDirPath),
+                 equalTo(tmpFileFixture.tempFilePath.getFileName()));
+    }
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 public class FileResponderDataSourceImplIntegrationTest {
   @Test
@@ -39,6 +40,21 @@ public class FileResponderDataSourceImplIntegrationTest {
                  is(false));
       assertThat(dataSource.getDirectoryContents(tmpFileFixture.tempFilePath.getFileName()),
                  is(nullValue()));
+    }
+  }
+
+  @Test
+  void returnsAllFilesInDirWithMultipleFiles() {
+    try (var tmpDirFixture = new TempDirectoryFixture();
+        var tmpFileFixture1 = new TempFileFixture(tmpDirFixture.tempDirPath);
+        var tmpFileFixture2 = new TempFileFixture(tmpDirFixture.tempDirPath)) {
+      var dataSource =
+          new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath);
+
+      assertThat(dataSource.getDirectoryContents(Paths.get("/")),
+                 containsInAnyOrder(List.of(
+                     tmpFileFixture1.tempFilePath.getFileName(),
+                     tmpFileFixture2.tempFilePath.getFileName())));
     }
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
@@ -5,6 +5,9 @@ import com.eighthlight.fabrial.test.file.TempDirectoryFixture;
 import com.eighthlight.fabrial.test.file.TempFileFixture;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Paths;
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -15,12 +18,12 @@ public class FileResponderDataSourceImplIntegrationTest {
          var tmpFileFixture = new TempFileFixture(tmpDirFixture.tempDirPath)) {
       var dataSource = new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath);
 
-      assertThat(dataSource.fileExistsAtPath(tmpDirFixture.tempDirPath), equalTo(true));
+      assertThat(dataSource.fileExistsAtPath(Paths.get("/")), equalTo(true));
 
-      assertThat(dataSource.isDirectory(tmpDirFixture.tempDirPath), equalTo(true));
+      assertThat(dataSource.isDirectory(Paths.get("/")), equalTo(true));
 
-      assertThat(dataSource.getDirectoryContents(tmpDirFixture.tempDirPath),
-                 equalTo(tmpFileFixture.tempFilePath.getFileName()));
+      assertThat(dataSource.getDirectoryContents(Paths.get("/")),
+                 equalTo(List.of(tmpFileFixture.tempFilePath.getFileName())));
     }
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FileResponderDataSourceImplIntegrationTest {
@@ -24,6 +25,17 @@ public class FileResponderDataSourceImplIntegrationTest {
 
       assertThat(dataSource.getDirectoryContents(Paths.get("/")),
                  equalTo(List.of(tmpFileFixture.tempFilePath.getFileName())));
+    }
+  }
+
+  @Test
+  void returnsNullWhenNotDirectory() {
+    try (var tmpFileFixture = new TempFileFixture(Paths.get("/tmp"))) {
+      var dataSource =
+          new FileResponderDataSourceImpl(tmpFileFixture.tempFilePath.getParent().toAbsolutePath());
+
+      assertThat(dataSource.getDirectoryContents(tmpFileFixture.tempFilePath.getFileName()),
+                 equalTo(nullValue()));
     }
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
@@ -8,9 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
@@ -50,11 +48,9 @@ public class FileResponderDataSourceImplIntegrationTest {
         var tmpFileFixture2 = new TempFileFixture(tmpDirFixture.tempDirPath)) {
       var dataSource =
           new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath);
-
       assertThat(dataSource.getDirectoryContents(Paths.get("/")),
-                 containsInAnyOrder(
-                     tmpFileFixture1.tempFilePath.getFileName(),
-                     tmpFileFixture2.tempFilePath.getFileName()));
+                 containsInAnyOrder(tmpFileFixture1.tempFilePath.getFileName(),
+                                    tmpFileFixture2.tempFilePath.getFileName()));
     }
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileResponderDataSourceImplIntegrationTest.java
@@ -35,6 +35,8 @@ public class FileResponderDataSourceImplIntegrationTest {
       var dataSource =
           new FileResponderDataSourceImpl(tmpFileFixture.tempFilePath.getParent().toAbsolutePath());
 
+      assertThat(dataSource.isDirectory(tmpFileFixture.tempFilePath.getFileName()),
+                 is(false));
       assertThat(dataSource.getDirectoryContents(tmpFileFixture.tempFilePath.getFileName()),
                  is(nullValue()));
     }

--- a/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.AllOf.allOf;
 

--- a/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
@@ -162,30 +162,4 @@ public class AppAcceptanceTest {
           });
     }
   }
-
-  @Test
-  void getEmptyDirContents() throws IOException {
-    int testPort = 8082;
-    try (var tempDirectoryFixture = new TempDirectoryFixture();
-        var appFixture = new AppProcessFixture(testPort, tempDirectoryFixture.tempDirPath.toString())) {
-      Files
-          .find(tempDirectoryFixture.tempDirPath,
-                1,
-                (p, attrs) -> attrs.isDirectory())
-          .forEach((path) -> {
-            var response = responseToRequestForFileInDir(Method.GET,
-                                                         tempDirectoryFixture.tempDirPath,
-                                                         path,
-                                                         testPort);
-            assertThat(response.get(0),
-                       startsWith("HTTP/1.1 200 "));
-            var headers = response.subList(1,3);
-            assertThat(headers,
-                       containsInAnyOrder(
-                           "Content-Length: " + 0,
-                           "Content-Type: text/plain; charset=utf-8"));
-            assertThat(response, hasSize(4));
-          });
-    }
-  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.AllOf.allOf;
 
@@ -158,6 +159,32 @@ public class AppAcceptanceTest {
                            "Content-Type: text/plain; charset=utf-8"));
             var body = response.get(4);
             assertThat(body, equalTo(expectedBody));
+          });
+    }
+  }
+
+  @Test
+  void getEmptyDirContents() throws IOException {
+    int testPort = 8082;
+    try (var tempDirectoryFixture = new TempDirectoryFixture();
+        var appFixture = new AppProcessFixture(testPort, tempDirectoryFixture.tempDirPath.toString())) {
+      Files
+          .find(tempDirectoryFixture.tempDirPath,
+                1,
+                (p, attrs) -> attrs.isDirectory())
+          .forEach((path) -> {
+            var response = responseToRequestForFileInDir(Method.GET,
+                                                         tempDirectoryFixture.tempDirPath,
+                                                         path,
+                                                         testPort);
+            assertThat(response.get(0),
+                       startsWith("HTTP/1.1 200 "));
+            var headers = response.subList(1,3);
+            assertThat(headers,
+                       containsInAnyOrder(
+                           "Content-Length: " + 0,
+                           "Content-Type: text/plain; charset=utf-8"));
+            assertThat(response, hasSize(4));
           });
     }
   }

--- a/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
@@ -62,7 +62,7 @@ public class AppAcceptanceTest {
   void clientConnectsToAppServer() throws IOException {
     int testPort = 8081;
     try (AppProcessFixture appFixture = new AppProcessFixture(testPort , null);
-        TcpClientFixture clientFixture = new TcpClientFixture(testPort )) {
+        TcpClientFixture clientFixture = new TcpClientFixture(testPort)) {
       clientFixture.client.connect(1000, 3, 1000);
     }
   }


### PR DESCRIPTION
> Resolves #18

Respond to GET requests for directories with a 200 response which has the filenames in that directory as the body.

GET requests for files which aren't directories should return a 501 response (for now).