### PR TITLE
Add content-type header to GET file responses

### DIFF
--- a/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
+++ b/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
@@ -37,6 +37,7 @@ public class HttpConnectionHandler implements ConnectionHandler {
     try {
       request = new RequestReader(is).readRequest();
     } catch (RequestParsingException e) {
+      logger.info("Failed to parse request, responding with 400", e);
       new ResponseWriter(os)
           .writeResponse(
               new ResponseBuilder()

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -42,6 +42,8 @@ public class FileHttpResponder implements HttpResponder {
 
     long getFileSize(String relPathStr);
 
+    String getFileMimeType(String relPathStr) throws IOException;
+
     InputStream getFileContents(String relPathStr) throws IOException;
   }
 

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -75,8 +75,11 @@ public class FileHttpResponder implements HttpResponder {
       case OPTIONS: {
         return buildOptionsResponse(request, builder);
       }
+      case PUT: {
+        return builder.withStatusCode(501).withReason("coming soon!").build();
+      }
       default:
-        return builder.withStatusCode(501).build();
+        return builder.withStatusCode(405).build();
     }
   }
 

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -110,11 +110,12 @@ public class FileHttpResponder implements HttpResponder {
                     .build();
     }
     try {
-      return builder.withStatusCode(200)
-                    // TODO: add content-type
-                    .withBody(dataSource.getFileContents(request.uri.getPath()))
-                    .withHeader("Content-Length", Long.toString(size))
-                    .build();
+      return builder
+          .withStatusCode(200)
+          .withHeader("Content-Type", dataSource.getFileMimeType(request.uri.getPath()))
+          .withHeader("Content-Length", Long.toString(size))
+          .withBody(dataSource.getFileContents(request.uri.getPath()))
+          .build();
     } catch (FileNotFoundException e) {
       logger.warn("Unexpected FileNotFoundException getting contents for {}",
                   StructuredArguments.kv("request", request.uri.getPath()));

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -54,5 +55,10 @@ public class FileResponderDataSourceImpl implements FileHttpResponder.DataSource
   @Override
   public InputStream getFileContents(String relPathStr) throws IOException {
     return new FileInputStream(absolutePathInBaseDir(relPathStr).toFile());
+  }
+
+  @Override
+  public String getFileMimeType(String relPathStr) throws IOException {
+    return Files.probeContentType(absolutePathInBaseDir(relPathStr));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
@@ -4,176 +4,140 @@ import com.eighthlight.fabrial.http.HttpVersion;
 import com.eighthlight.fabrial.http.Method;
 import com.eighthlight.fabrial.http.file.FileHttpResponder;
 import com.eighthlight.fabrial.http.file.FileResponderDataSourceImpl;
-import com.eighthlight.fabrial.http.request.Request;
 import com.eighthlight.fabrial.http.request.RequestBuilder;
-import com.eighthlight.fabrial.http.response.ResponseBuilder;
 import com.eighthlight.fabrial.utils.Result;
 import org.junit.jupiter.api.Test;
-import org.quicktheories.api.Subject1;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.eighthlight.fabrial.test.http.ArbitraryHttp.paths;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.Generate.pick;
-import static org.quicktheories.generators.SourceDSL.lists;
 import static org.quicktheories.generators.SourceDSL.strings;
 
 public class FileHttpResponderTest {
-  static final Subject1<List<HashSet<String>>> forAllListsOfExistingAndNonExistingFiles() {
-    return qt().forAll(lists().of(paths(32)).ofSizeBetween(1, 5),
-                       lists().of(paths(32)).ofSizeBetween(1, 5))
-               .as((paths1, paths2) -> {
-                 HashSet<String> ps1 = new HashSet<>(paths1);
-                 ps1.removeAll(paths2);
-                 HashSet<String> ps2 = new HashSet<>(paths2);
-                 ps2.removeAll(paths1);
-                 return List.of(ps1, ps2);
-               });
-  }
-
-  static FileHttpResponder responderForListOfExistingFiles(Set<String> files) {
-    return new FileHttpResponder(new FileHttpResponder.DataSource() {
-      @Override
-      public boolean fileExistsAtPath(String relPathStr) {
-        return files.contains(relPathStr);
-      }
-
-      @Override
-      public boolean isDirectory(String relPathStr) {
-        return false;
-      }
-
-      @Override
-      public List<String> getDirectoryContents(String relPathStr) {
-        return List.of();
-      }
-
-      @Override
-      public long getFileSize(String relPathStr) {
-        throw new IllegalCallerException();
-      }
-
-      @Override
-      public InputStream getFileContents(String relPathStr) {
-        throw new IllegalCallerException();
-      }
-
-      @Override
-      public String getFileMimeType(String relPathStr) {
-        return null;
-      }
-    });
-  }
-
-
   @Test
-  void responds200ToHeadForExistingFiles() {
-    forAllListsOfExistingAndNonExistingFiles()
-        .checkAssert((files) -> {
-          Set<String> existingFilePaths = files.get(0);
-          Set<String> nonExistingFilePaths = files.get(1);
-          FileHttpResponder responder = responderForListOfExistingFiles(existingFilePaths);
-          ArrayList<String> allFilePaths = new ArrayList<>();
-          allFilePaths.addAll(existingFilePaths);
-          allFilePaths.addAll(nonExistingFilePaths);
-          allFilePaths.forEach(p -> {
-            Request req = new Request(HttpVersion.ONE_ONE, Method.HEAD, Result.attempt(() -> new URI(p)).orElseAssert());
-            int expectedStatus = existingFilePaths.contains(p) ? 200 : 404;
-            assertThat(
-                responder.getResponse(req),
-                equalTo(new ResponseBuilder()
-                            .withVersion(HttpVersion.ONE_ONE)
-                            .withStatusCode(expectedStatus)
-                            .build()));
-          });
-        });
+  void headEmptyFile() {
+    try (var tmpFileFixture = new TempFileFixture()) {
+      var responder = new FileHttpResponder(
+          new FileResponderDataSourceImpl(tmpFileFixture.tempFilePath.getParent()));
+      var response = responder.getResponse(
+          new RequestBuilder()
+              .withVersion(HttpVersion.ONE_ONE)
+              .withMethod(Method.HEAD)
+              .withUriString(tmpFileFixture.tempFilePath.getFileName().toString())
+              .build());
+      assertThat(response.statusCode, is(200));
+      assertThat(response.headers, hasEntry("Content-Length", "0"));
+    }
   }
 
   @Test
-  void responds501ToUnsupportedMethodsOnExistingFiles() {
-    forAllListsOfExistingAndNonExistingFiles()
-        .checkAssert((files) -> {
-          Set<String> existingFilePaths = files.get(0);
-          Set<String> nonExistingFilePaths = files.get(1);
-          FileHttpResponder responder = responderForListOfExistingFiles(existingFilePaths);
-          existingFilePaths.forEach(p -> {
-            Request req =
-                new Request(HttpVersion.ONE_ONE,
-                            Method.DELETE,
-                            Result.attempt(() -> new URI(p.toString())).orElseAssert());
-            assertThat(
-                responder.getResponse(req),
-                equalTo(new ResponseBuilder()
-                            .withVersion(HttpVersion.ONE_ONE)
-                            .withStatusCode(501)
-                            .build()));
-          });
-        });
+  void headAbsentFileNotFound() {
+    try (var tmpDirFixture = new TempDirectoryFixture()) {
+      var responder = new FileHttpResponder(
+          new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath));
+      var response = responder.getResponse(
+          new RequestBuilder()
+              .withVersion(HttpVersion.ONE_ONE)
+              .withMethod(Method.HEAD)
+              .withUriString("/foo")
+              .build());
+      assertThat(response.statusCode, is(404));
+      assertThat(response.headers, is(anEmptyMap()));
+      assertThat(response.body, is(nullValue()));
+    }
   }
 
   @Test
-  void responds404ToUnsupportedMethodsOnNonExistingFiles() {
-    forAllListsOfExistingAndNonExistingFiles()
-        .checkAssert((files) -> {
-          Set<String> existingFilePaths = files.get(0);
-          Set<String> nonExistingFilePaths = files.get(1);
-          FileHttpResponder responder = responderForListOfExistingFiles(existingFilePaths);
-          nonExistingFilePaths.forEach(p -> {
-            Request req =
-                new Request(HttpVersion.ONE_ONE,
-                            Method.DELETE,
-                            Result.attempt(() -> new URI(p.toString())).orElseAssert());
-            assertThat(
-                responder.getResponse(req),
-                equalTo(new ResponseBuilder()
-                            .withVersion(HttpVersion.ONE_ONE)
-                            .withStatusCode(404)
-                            .build()));
-          });
-        });
+  void headTextFile() {
+    try (var tmpFileFixture = new TempFileFixture(Paths.get("/tmp"), ".txt")) {
+      var data = "foo".getBytes();
+      tmpFileFixture.write(new ByteArrayInputStream(data));
+      var responder = new FileHttpResponder(
+          new FileResponderDataSourceImpl(tmpFileFixture.tempFilePath.getParent()));
+      var response = responder.getResponse(
+          new RequestBuilder()
+              .withVersion(HttpVersion.ONE_ONE)
+              .withMethod(Method.HEAD)
+              .withUriString(tmpFileFixture.tempFilePath.getFileName().toString())
+              .build());
+      assertThat(response.statusCode, is(200));
+      assertThat(response.headers, hasEntry("Content-Length", Long.toString(data.length)));
+      assertThat(response.headers, hasEntry("Content-Type", "text/plain"));
+    }
   }
 
   @Test
-  void responds200WithAllowToOptionsOnAnyPath() {
-    forAllListsOfExistingAndNonExistingFiles()
-        .checkAssert((files) -> {
-          Set<String> existingFilePaths = files.get(0);
-          Set<String> nonExistingFilePaths = files.get(1);
-          FileHttpResponder responder = responderForListOfExistingFiles(existingFilePaths);
-          ArrayList<String> allFilePaths = new ArrayList<>();
-          allFilePaths.addAll(existingFilePaths);
-          allFilePaths.addAll(nonExistingFilePaths);
-          allFilePaths.forEach(p -> {
-            Request req =
-                new Request(HttpVersion.ONE_ONE,
-                            Method.OPTIONS,
-                            Result.attempt(() -> new URI(p.toString())).orElseAssert());
-            var resp = responder.getResponse(req);
-            assertThat(resp.version, equalTo(HttpVersion.ONE_ONE));
-            assertThat(resp.statusCode, equalTo(200));
-            assertThat(resp.reason, nullValue());
-            assertThat(Arrays.asList(resp.headers.get("Allow").split(", ")),
-                       allOf(
-                           containsInAnyOrder("GET", "HEAD", "OPTIONS", "PUT", "DELETE"),
-                           not(contains("POST"))));
-            assertThat(resp.headers.get("Content-Length"),
-                       is("0"));
-          });
-        });
+  void unsupportedMethodOnExistingFile() {
+    try (var tmpFileFixture = new TempFileFixture()) {
+      var responder = new FileHttpResponder(
+          new FileResponderDataSourceImpl(tmpFileFixture.tempFilePath.getParent()));
+      var response = responder.getResponse(
+          new RequestBuilder()
+              .withVersion(HttpVersion.ONE_ONE)
+              .withMethod(Method.POST)
+              .withUriString(tmpFileFixture.tempFilePath.getFileName().toString())
+              .build());
+      assertThat(response.statusCode, is(405));
+      assertThat(response.headers, is(anEmptyMap()));
+      assertThat(response.body, is(nullValue()));
+    }
+  }
+
+  @Test
+  void unsupportedMethodOnAbsentFile() {
+    try (var tmpDirFixture = new TempDirectoryFixture()) {
+      var responder = new FileHttpResponder(
+          new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath));
+      var response = responder.getResponse(
+          new RequestBuilder()
+              .withVersion(HttpVersion.ONE_ONE)
+              .withMethod(Method.POST)
+              .withUriString("/foo")
+              .build());
+      assertThat(response.statusCode, is(404));
+      assertThat(response.headers, is(anEmptyMap()));
+      assertThat(response.body, is(nullValue()));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/", "/foo"})
+  void optionsOnAbsentOrExistingFile(String path) {
+    try (var tmpDirFixture = new TempDirectoryFixture()) {
+      var responder = new FileHttpResponder(
+          new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath));
+      var response = responder.getResponse(
+          new RequestBuilder()
+              .withVersion(HttpVersion.ONE_ONE)
+              .withMethod(Method.OPTIONS)
+              .withUriString(path)
+              .build());
+      assertThat(response.statusCode, is(200));
+      assertThat(response.headers, allOf(
+          hasEntry(is("Allow"), allOf(containsString("GET"),
+                                      containsString("DELETE"),
+                                      containsString("PUT"),
+                                      containsString("HEAD"),
+                                      containsString("OPTIONS"))),
+          hasEntry("Content-Length", "0")));
+      assertThat(response.body, is(nullValue()));
+    }
   }
 
   @Test
@@ -252,6 +216,7 @@ public class FileHttpResponderTest {
               .build());
       assertThat(response.statusCode, is(200));
       assertThat(response.headers, hasEntry("Content-Length", "0"));
+      assertThat(response.body, is(nullValue()));
     }
   }
 

--- a/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -48,9 +49,38 @@ public class FileHttpResponderTest {
 
   @Test
   void headAbsentFileNotFound() {
-    try (var tmpDirFixture = new TempDirectoryFixture()) {
-      var responder = new FileHttpResponder(
-          new FileResponderDataSourceImpl(tmpDirFixture.tempDirPath));
+//    try (var tmpDirFixture = new TempDirectoryFixture()) {
+      var responder = new FileHttpResponder(new FileHttpResponder.DataSource() {
+        @Override
+        public boolean fileExistsAtPath(String relPathStr) {
+          return false;
+        }
+
+        @Override
+        public boolean isDirectory(String relPathStr) {
+          return false;
+        }
+
+        @Override
+        public List<String> getDirectoryContents(String relPathStr) {
+          return null;
+        }
+
+        @Override
+        public long getFileSize(String relPathStr) {
+          return 0;
+        }
+
+        @Override
+        public String getFileMimeType(String relPathStr) throws IOException {
+          return null;
+        }
+
+        @Override
+        public InputStream getFileContents(String relPathStr) throws IOException {
+          return null;
+        }
+      });
       var response = responder.getResponse(
           new RequestBuilder()
               .withVersion(HttpVersion.ONE_ONE)
@@ -60,7 +90,7 @@ public class FileHttpResponderTest {
       assertThat(response.statusCode, is(404));
       assertThat(response.headers, is(anEmptyMap()));
       assertThat(response.body, is(nullValue()));
-    }
+//    }
   }
 
   @Test

--- a/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/file/FileHttpResponderTest.java
@@ -70,6 +70,11 @@ public class FileHttpResponderTest {
       public InputStream getFileContents(String relPathStr) {
         throw new IllegalCallerException();
       }
+
+      @Override
+      public String getFileMimeType(String relPathStr) {
+        return null;
+      }
     });
   }
 
@@ -251,7 +256,7 @@ public class FileHttpResponderTest {
 
   @Test
   void getFileReturnsContents() {
-    try (var tmpFileFixture = new TempFileFixture()) {
+    try (var tmpFileFixture = new TempFileFixture(Paths.get("/tmp"), ".txt")) {
       var data = "foo".getBytes();
       tmpFileFixture.write(new ByteArrayInputStream(data));
       var responder = new FileHttpResponder(
@@ -265,7 +270,10 @@ public class FileHttpResponderTest {
               .build());
 
       assertThat(response.statusCode, is(200));
-      assertThat(response.headers, hasEntry("Content-Length", Long.toString(data.length)));
+      assertThat(response.headers, allOf(
+          hasEntry("Content-Length", Long.toString(data.length)),
+          hasEntry("Content-Type", "text/plain")
+      ));
 
       var bodyBytes =
           Optional.ofNullable(response.body)

--- a/src/test/java/com/eighthlight/fabrial/test/file/TempFileFixture.java
+++ b/src/test/java/com/eighthlight/fabrial/test/file/TempFileFixture.java
@@ -15,12 +15,16 @@ public class TempFileFixture implements AutoCloseable {
   public final Path tempFilePath;
 
   public TempFileFixture() {
-    this(Paths.get("/tmp"));
+    this(Paths.get("/tmp", null));
   }
 
   public TempFileFixture(Path dir) {
+    this(dir, null);
+  }
+
+  public TempFileFixture(Path dir, String suffix) {
     tempFilePath =
-        attempt(() -> Files.createTempFile(dir, "test", null))
+        attempt(() -> Files.createTempFile(dir, "test", suffix))
               .orElseAssert();
   }
 

--- a/src/test/java/com/eighthlight/fabrial/test/file/TempFileFixture.java
+++ b/src/test/java/com/eighthlight/fabrial/test/file/TempFileFixture.java
@@ -15,7 +15,7 @@ public class TempFileFixture implements AutoCloseable {
   public final Path tempFilePath;
 
   public TempFileFixture() {
-    this(Paths.get("/tmp", null));
+    this(Paths.get("/tmp"), null);
   }
 
   public TempFileFixture(Path dir) {


### PR DESCRIPTION
> Resolves #31

Using pre-existing API to look up the mime type (primarily testing based on expected MIME types for certain extensions).