### PR TITLE
Add header & body parsing for HTTP requests

### DIFF
--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -45,6 +45,8 @@ public class FileHttpResponder implements HttpResponder {
     String getFileMimeType(String relPathStr) throws IOException;
 
     InputStream getFileContents(String relPathStr) throws IOException;
+
+    void updateFileContents(String relPathStr, InputStream data) throws IOException;
   }
 
   public FileHttpResponder(DataSource dataSource) {

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileResponderDataSourceImpl.java
@@ -1,9 +1,6 @@
 package com.eighthlight.fabrial.http.file;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,5 +57,10 @@ public class FileResponderDataSourceImpl implements FileHttpResponder.DataSource
   @Override
   public String getFileMimeType(String relPathStr) throws IOException {
     return Files.probeContentType(absolutePathInBaseDir(relPathStr));
+  }
+
+  @Override
+  public void updateFileContents(String relPathStr, InputStream data) throws IOException {
+
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
@@ -4,6 +4,8 @@ import java.io.InputStream;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
+import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
+
 /**
  * Scans an input string for header fields and values.
  *
@@ -27,8 +29,8 @@ import java.util.regex.Pattern;
  *
  */
 public class HttpHeaderReader {
-  private static final Pattern FIELD_NAME_PATTERN = Pattern.compile("^([!#$%&'*+-.\\^_'|~0-9a-zA-Z]+):");
-  private static final Pattern FIELD_VALUE_PATTERN = Pattern.compile(" *([^:]+) *$");
+  private static final Pattern FIELD_NAME_PATTERN = Pattern.compile("([!#$%&'*+-.\\^_'|~0-9a-zA-Z]+):");
+  private static final Pattern FIELD_VALUE_PATTERN = Pattern.compile(" *([^:]+)");
 
   private final Scanner scanner;
 
@@ -37,7 +39,7 @@ public class HttpHeaderReader {
   }
 
 
-  public String getFieldName() {
+  public String nextFieldName() {
     if (scanner.hasNext(FIELD_NAME_PATTERN)) {
       scanner.findInLine(FIELD_NAME_PATTERN);
       return scanner.match().group(1);
@@ -45,11 +47,15 @@ public class HttpHeaderReader {
     return null;
   }
 
-  public String getFieldValue() {
+  public String nextFieldValue() {
     if (scanner.hasNext(FIELD_VALUE_PATTERN)) {
       scanner.findInLine(FIELD_VALUE_PATTERN);
-      return scanner.match().group(1);
+      return scanner.match().group(1).trim();
     }
     return null;
+  }
+
+  public void skipToNextLine() {
+    scanner.skip(" *"+CRLF);
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
@@ -1,6 +1,5 @@
 package com.eighthlight.fabrial.http.request;
 
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +36,7 @@ public class HttpHeaderReader {
 
   private final Scanner scanner;
 
-  public HttpHeaderReader(InputStream is) {
+  public HttpHeaderReader(Readable is) {
     this.scanner = new Scanner(is);
   }
 

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
@@ -1,6 +1,8 @@
 package com.eighthlight.fabrial.http.request;
 
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
@@ -38,9 +40,8 @@ public class HttpHeaderReader {
     this.scanner = new Scanner(is);
   }
 
-
   public String nextFieldName() {
-    if (scanner.hasNext(FIELD_NAME_PATTERN)) {
+    if (hasNext()) {
       scanner.findInLine(FIELD_NAME_PATTERN);
       return scanner.match().group(1);
     }
@@ -57,5 +58,18 @@ public class HttpHeaderReader {
 
   public void skipToNextLine() {
     scanner.skip(" *"+CRLF);
+  }
+
+  public boolean hasNext() {
+    return scanner.hasNext(FIELD_NAME_PATTERN);
+  }
+
+  public Map<String, String> readHeaders() {
+    var headers = new HashMap<String, String>();
+    while (hasNext()) {
+      headers.put(nextFieldName(), nextFieldValue());
+      skipToNextLine();
+    }
+    return headers;
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
@@ -3,6 +3,7 @@ package com.eighthlight.fabrial.http.request;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
@@ -62,10 +63,7 @@ public class HttpHeaderReader {
     var headers = new HashMap<String, String>();
     var fieldName = nextFieldName();
     while (fieldName != null) {
-      var fieldValue = nextFieldValue();
-      if (fieldValue != null) {
-        headers.put(fieldName, fieldValue);
-      }
+      headers.put(fieldName, Optional.ofNullable(nextFieldValue()).orElse(""));
       skipToNextLine();
       fieldName = nextFieldName();
     }

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
@@ -41,16 +41,14 @@ public class HttpHeaderReader {
   }
 
   public String nextFieldName() {
-    if (hasNext()) {
-      scanner.findInLine(FIELD_NAME_PATTERN);
+    if (scanner.findInLine(FIELD_NAME_PATTERN) != null) {
       return scanner.match().group(1);
     }
     return null;
   }
 
   public String nextFieldValue() {
-    if (scanner.hasNext(FIELD_VALUE_PATTERN)) {
-      scanner.findInLine(FIELD_VALUE_PATTERN);
+    if (scanner.findInLine(FIELD_VALUE_PATTERN) != null) {
       return scanner.match().group(1).trim();
     }
     return null;
@@ -60,15 +58,13 @@ public class HttpHeaderReader {
     scanner.skip(" *"+CRLF);
   }
 
-  public boolean hasNext() {
-    return scanner.hasNext(FIELD_NAME_PATTERN);
-  }
-
   public Map<String, String> readHeaders() {
     var headers = new HashMap<String, String>();
-    while (hasNext()) {
-      headers.put(nextFieldName(), nextFieldValue());
+    var fieldName = nextFieldName();
+    while (fieldName != null) {
+      headers.put(fieldName, nextFieldValue());
       skipToNextLine();
+      fieldName = nextFieldName();
     }
     return headers;
   }

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
@@ -62,7 +62,10 @@ public class HttpHeaderReader {
     var headers = new HashMap<String, String>();
     var fieldName = nextFieldName();
     while (fieldName != null) {
-      headers.put(fieldName, nextFieldValue());
+      var fieldValue = nextFieldValue();
+      if (fieldValue != null) {
+        headers.put(fieldName, fieldValue);
+      }
       skipToNextLine();
       fieldName = nextFieldName();
     }

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
@@ -1,0 +1,19 @@
+package com.eighthlight.fabrial.http.request;
+
+import java.io.InputStream;
+
+public class HttpHeaderReader {
+  private final InputStream is;
+
+  public HttpHeaderReader(InputStream is) {
+    this.is = is;
+  }
+
+  public String getKey() {
+    return null;
+  }
+
+  public String getValue() {
+    return null;
+  }
+}

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpHeaderReader.java
@@ -1,19 +1,55 @@
 package com.eighthlight.fabrial.http.request;
 
 import java.io.InputStream;
+import java.util.Scanner;
+import java.util.regex.Pattern;
 
+/**
+ * Scans an input string for header fields and values.
+ *
+ * Based on RFC7320 Section 3.2:
+ *
+ *      header-field   = field-name ":" OWS field-value OWS
+ *      field-name     = token
+ *      field-value    = *(field-content / obs-fold)
+ *      field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+ *      field-vchar    = VCHAR / obs-text
+ *      obs-fold       = CRLF 1*( SP / HTAB )
+ *                     ; obsolete line folding
+ *
+ * Where:
+ *      token = 1*tchar
+ *      tchar = "!" / "#" / "$" / "%" / "&" / "’" / "*" / "+" / "-" / "." /
+ *  "^" / "_" / "‘" / "|" / "~" / DIGIT / ALPHA
+ *      OWS = *( SP / HTAB )
+ *
+ *  and "VCHAR" is any visible ASCII character. Field values also can't contain delimiters (e.g. ":").
+ *
+ */
 public class HttpHeaderReader {
-  private final InputStream is;
+  private static final Pattern FIELD_NAME_PATTERN = Pattern.compile("^([!#$%&'*+-.\\^_'|~0-9a-zA-Z]+):");
+  private static final Pattern FIELD_VALUE_PATTERN = Pattern.compile(" *([^:]+) *$");
+
+  private final Scanner scanner;
 
   public HttpHeaderReader(InputStream is) {
-    this.is = is;
+    this.scanner = new Scanner(is);
   }
 
-  public String getKey() {
+
+  public String getFieldName() {
+    if (scanner.hasNext(FIELD_NAME_PATTERN)) {
+      scanner.findInLine(FIELD_NAME_PATTERN);
+      return scanner.match().group(1);
+    }
     return null;
   }
 
-  public String getValue() {
+  public String getFieldValue() {
+    if (scanner.hasNext(FIELD_VALUE_PATTERN)) {
+      scanner.findInLine(FIELD_VALUE_PATTERN);
+      return scanner.match().group(1);
+    }
     return null;
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/request/Request.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/Request.java
@@ -3,7 +3,7 @@ package com.eighthlight.fabrial.http.request;
 import com.eighthlight.fabrial.http.HttpVersion;
 import com.eighthlight.fabrial.http.Method;
 
-import java.io.Reader;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
@@ -14,7 +14,7 @@ public class Request {
   public final Method method;
   public final URI uri;
   public final Map<String, String> headers;
-  public final Reader body;
+  public final InputStream body;
 
   public Request(String version,
                  Method method,
@@ -26,7 +26,7 @@ public class Request {
                  Method method,
                  URI uri,
                  Map<String, String> headers,
-                 Reader body) {
+                 InputStream body) {
     if (!HttpVersion.allVersions.contains(version)) {
       throw new IllegalArgumentException("Unexpected HTTP version: " + version);
     }

--- a/src/main/java/com/eighthlight/fabrial/http/request/Request.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/Request.java
@@ -3,7 +3,7 @@ package com.eighthlight.fabrial.http.request;
 import com.eighthlight.fabrial.http.HttpVersion;
 import com.eighthlight.fabrial.http.Method;
 
-import java.io.InputStream;
+import java.io.Reader;
 import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
@@ -14,7 +14,7 @@ public class Request {
   public final Method method;
   public final URI uri;
   public final Map<String, String> headers;
-  public final InputStream body;
+  public final Reader body;
 
   public Request(String version,
                  Method method,
@@ -26,7 +26,7 @@ public class Request {
                  Method method,
                  URI uri,
                  Map<String, String> headers,
-                 InputStream body) {
+                 Reader body) {
     if (!HttpVersion.allVersions.contains(version)) {
       throw new IllegalArgumentException("Unexpected HTTP version: " + version);
     }

--- a/src/main/java/com/eighthlight/fabrial/http/request/Request.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/Request.java
@@ -5,30 +5,45 @@ import com.eighthlight.fabrial.http.Method;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public class Request {
   public final String version;
   public final Method method;
   public final URI uri;
+  public final Map<String, String> headers;
   public final InputStream body;
 
-  public Request(String version, Method method, URI uri, InputStream body) {
+  public Request(String version,
+                 Method method,
+                 URI uri) {
+    this(version, method, uri, null, null);
+  }
+
+  public Request(String version,
+                 Method method,
+                 URI uri,
+                 Map<String, String> headers,
+                 InputStream body) {
     if (!HttpVersion.allVersions.contains(version)) {
       throw new IllegalArgumentException("Unexpected HTTP version: " + version);
     }
-    this.version = version;
-    this.method = method;
-    this.uri = uri;
+    this.version = Objects.requireNonNull(version);
+    this.method = Objects.requireNonNull(method);
+    this.uri = Objects.requireNonNull(uri);
+    this.headers = Optional.ofNullable(headers).map(Map::copyOf).orElse(Map.of());
     this.body = body;
   }
-  
+
   @Override
   public String toString() {
     return "Request{" +
            "version='" + version + '\'' +
            ", method=" + method +
            ", uri=" + uri +
+           ", headers=" + headers +
            '}';
   }
 
@@ -41,11 +56,12 @@ public class Request {
     Request request = (Request) o;
     return Objects.equals(version, request.version) &&
            method == request.method &&
-           Objects.equals(uri, request.uri);
+           Objects.equals(uri, request.uri) &&
+           Objects.equals(headers, request.headers);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, method, uri);
+    return Objects.hash(version, method, uri, headers);
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/request/Request.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/Request.java
@@ -3,6 +3,7 @@ package com.eighthlight.fabrial.http.request;
 import com.eighthlight.fabrial.http.HttpVersion;
 import com.eighthlight.fabrial.http.Method;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.util.Objects;
 
@@ -10,14 +11,16 @@ public class Request {
   public final String version;
   public final Method method;
   public final URI uri;
+  public final InputStream body;
 
-  public Request(String version, Method method, URI uri) {
+  public Request(String version, Method method, URI uri, InputStream body) {
     if (!HttpVersion.allVersions.contains(version)) {
       throw new IllegalArgumentException("Unexpected HTTP version: " + version);
     }
     this.version = version;
     this.method = method;
     this.uri = uri;
+    this.body = body;
   }
   
   @Override

--- a/src/main/java/com/eighthlight/fabrial/http/request/RequestBuilder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/RequestBuilder.java
@@ -5,14 +5,15 @@ import com.eighthlight.fabrial.http.Method;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 public class RequestBuilder {
   private String version;
   private Method method;
   private URI uri;
   private InputStream body;
+  private Map<String, String> headers;
 
   public RequestBuilder() {}
 
@@ -55,6 +56,11 @@ public class RequestBuilder {
     return this;
   }
 
+  public RequestBuilder withHeaders(Map<String, String> headers) {
+    this.headers = Map.copyOf(headers);
+    return this;
+  }
+
   public RequestBuilder withBody(InputStream body) {
     this.body = body;
     return this;
@@ -62,10 +68,7 @@ public class RequestBuilder {
 
   public Request build() {
     try {
-      return new Request(Optional.ofNullable(version).orElseThrow(),
-                         Optional.ofNullable(method).orElseThrow(),
-                         Optional.ofNullable(uri).orElseThrow(),
-                         body);
+      return new Request(version, method, uri, headers, body);
     } catch (NoSuchElementException e) {
       throw new IllegalArgumentException(e);
     }

--- a/src/main/java/com/eighthlight/fabrial/http/request/RequestBuilder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/RequestBuilder.java
@@ -2,7 +2,7 @@ package com.eighthlight.fabrial.http.request;
 
 import com.eighthlight.fabrial.http.Method;
 
-import java.io.Reader;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -12,7 +12,7 @@ public class RequestBuilder {
   public String version;
   public Method method;
   public URI uri;
-  public Reader body;
+  public InputStream body;
   public Map<String, String> headers;
 
   public RequestBuilder() {}
@@ -61,7 +61,7 @@ public class RequestBuilder {
     return this;
   }
 
-  public RequestBuilder withBody(Reader body) {
+  public RequestBuilder withBody(InputStream body) {
     this.body = body;
     return this;
   }

--- a/src/main/java/com/eighthlight/fabrial/http/request/RequestBuilder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/RequestBuilder.java
@@ -2,6 +2,7 @@ package com.eighthlight.fabrial.http.request;
 
 import com.eighthlight.fabrial.http.Method;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.NoSuchElementException;
@@ -11,6 +12,7 @@ public class RequestBuilder {
   private String version;
   private Method method;
   private URI uri;
+  private InputStream body;
 
   public RequestBuilder() {}
 
@@ -53,11 +55,17 @@ public class RequestBuilder {
     return this;
   }
 
+  public RequestBuilder withBody(InputStream body) {
+    this.body = body;
+    return this;
+  }
+
   public Request build() {
     try {
       return new Request(Optional.ofNullable(version).orElseThrow(),
                          Optional.ofNullable(method).orElseThrow(),
-                         Optional.ofNullable(uri).orElseThrow());
+                         Optional.ofNullable(uri).orElseThrow(),
+                         body);
     } catch (NoSuchElementException e) {
       throw new IllegalArgumentException(e);
     }

--- a/src/main/java/com/eighthlight/fabrial/http/request/RequestBuilder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/RequestBuilder.java
@@ -2,18 +2,18 @@ package com.eighthlight.fabrial.http.request;
 
 import com.eighthlight.fabrial.http.Method;
 
-import java.io.InputStream;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
 public class RequestBuilder {
-  private String version;
-  private Method method;
-  private URI uri;
-  private InputStream body;
-  private Map<String, String> headers;
+  public String version;
+  public Method method;
+  public URI uri;
+  public Reader body;
+  public Map<String, String> headers;
 
   public RequestBuilder() {}
 
@@ -61,7 +61,7 @@ public class RequestBuilder {
     return this;
   }
 
-  public RequestBuilder withBody(InputStream body) {
+  public RequestBuilder withBody(Reader body) {
     this.body = body;
     return this;
   }

--- a/src/main/java/com/eighthlight/fabrial/http/request/RequestReader.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/RequestReader.java
@@ -56,13 +56,7 @@ public class RequestReader {
             return b.withHeaders(headers);
           })
           .map(b -> {
-            var contentLength = Optional.ofNullable(b.headers.get("Content-Length"));
-            contentLength.flatMap((lenStr) -> {
-              return Result.attempt(() -> Long.decode(lenStr)).toOptional();
-            }).ifPresent((len) -> {
-              b.withBody(is);
-            });
-            return b.build();
+            return b.withBody(is).build();
           })
           .orElseThrow();
     } catch (Exception e) {

--- a/src/main/java/com/eighthlight/fabrial/utils/HttpLineReader.java
+++ b/src/main/java/com/eighthlight/fabrial/utils/HttpLineReader.java
@@ -2,20 +2,32 @@ package com.eighthlight.fabrial.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 
 public class HttpLineReader  {
   private final InputStream inputStream;
+  private final ByteBuffer charByteBuffer;
 
   public HttpLineReader(InputStream readable) {
     this.inputStream = readable;
+    this.charByteBuffer = ByteBuffer.allocate(4);
+  }
+
+  private Integer read() throws IOException {
+    charByteBuffer.clear();
+    var readResult = inputStream.read(charByteBuffer.array(), 0, 4);
+    if (readResult == -1) {
+      return null;
+    }
+    return charByteBuffer.asIntBuffer().get();
   }
 
   public String readLine() throws IOException {
     var builder = new StringBuilder();
-    var readChar = inputStream.read();
-    while (readChar != -1) {
+    var readChar = read();
+    while (readChar != null) {
       builder.appendCodePoint(readChar);
       var crlfIndex = builder.lastIndexOf(CRLF);
       if (crlfIndex != -1) {
@@ -23,7 +35,7 @@ public class HttpLineReader  {
         builder.replace(crlfIndex, crlfIndex + CRLF.length(), "");
         break;
       }
-      readChar = inputStream.read();
+      readChar = read();
     }
     return builder.toString();
   }

--- a/src/main/java/com/eighthlight/fabrial/utils/HttpLineReader.java
+++ b/src/main/java/com/eighthlight/fabrial/utils/HttpLineReader.java
@@ -1,0 +1,30 @@
+package com.eighthlight.fabrial.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
+
+public class HttpLineReader  {
+  private final InputStream inputStream;
+
+  public HttpLineReader(InputStream readable) {
+    this.inputStream = readable;
+  }
+
+  public String readLine() throws IOException {
+    var builder = new StringBuilder();
+    var readChar = inputStream.read();
+    while (readChar != -1) {
+      builder.appendCodePoint(readChar);
+      var crlfIndex = builder.lastIndexOf(CRLF);
+      if (crlfIndex != -1) {
+        // remove trailing newline, just like Scanner/BufferedReader would
+        builder.replace(crlfIndex, crlfIndex + CRLF.length(), "");
+        break;
+      }
+      readChar = inputStream.read();
+    }
+    return builder.toString();
+  }
+}

--- a/src/main/java/com/eighthlight/fabrial/utils/HttpLineReader.java
+++ b/src/main/java/com/eighthlight/fabrial/utils/HttpLineReader.java
@@ -2,32 +2,20 @@ package com.eighthlight.fabrial.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 
 import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 
 public class HttpLineReader  {
   private final InputStream inputStream;
-  private final ByteBuffer charByteBuffer;
 
   public HttpLineReader(InputStream readable) {
     this.inputStream = readable;
-    this.charByteBuffer = ByteBuffer.allocate(4);
-  }
-
-  private Integer read() throws IOException {
-    charByteBuffer.clear();
-    var readResult = inputStream.read(charByteBuffer.array(), 0, 4);
-    if (readResult == -1) {
-      return null;
-    }
-    return charByteBuffer.asIntBuffer().get();
   }
 
   public String readLine() throws IOException {
     var builder = new StringBuilder();
-    var readChar = read();
-    while (readChar != null) {
+    var readChar = inputStream.read();
+    while (readChar != -1) {
       builder.appendCodePoint(readChar);
       var crlfIndex = builder.lastIndexOf(CRLF);
       if (crlfIndex != -1) {
@@ -35,7 +23,7 @@ public class HttpLineReader  {
         builder.replace(crlfIndex, crlfIndex + CRLF.length(), "");
         break;
       }
-      readChar = read();
+      readChar = inputStream.read();
     }
     return builder.toString();
   }

--- a/src/main/java/com/eighthlight/fabrial/utils/HttpLineReader.java
+++ b/src/main/java/com/eighthlight/fabrial/utils/HttpLineReader.java
@@ -5,6 +5,12 @@ import java.io.InputStream;
 
 import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 
+/**
+ * Given an input stream, read ASCII strings separated by CRLF.
+ *
+ * Note that this assumes the data retrieved from the input stream is ASCII, since the HTTP message
+ * components are limited to ASCII.
+ */
 public class HttpLineReader  {
   private final InputStream inputStream;
 

--- a/src/test/java/com/eighthlight/fabrial/test/gen/ArbitraryStrings.java
+++ b/src/test/java/com/eighthlight/fabrial/test/gen/ArbitraryStrings.java
@@ -19,8 +19,7 @@ public class ArbitraryStrings {
     ).ofSize(length).map(chars ->
       chars.stream()
            .map(c -> Character.toString(c))
-           .reduce(String::concat)
-           .get()
+           .reduce("", String::concat)
     );
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryHttp.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryHttp.java
@@ -30,7 +30,7 @@ public class ArbitraryHttp {
   }
 
   public static Gen<Request> requests(Gen<Method> methods, Gen<URI> uris, Gen<String> versions) {
-    return versions.zip(methods, uris, Request::new);
+    return versions.zip(methods, uris, (v, m, u) -> new Request(v, m, u, null));
   }
 
   // !!!: all of these "length" args are rough approximations. proper DSL necessary

--- a/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryHttp.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryHttp.java
@@ -8,13 +8,12 @@ import org.quicktheories.core.Gen;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.eighthlight.fabrial.test.gen.ArbitraryStrings.alphanumeric;
 import static org.quicktheories.generators.Generate.*;
-import static org.quicktheories.generators.SourceDSL.integers;
-import static org.quicktheories.generators.SourceDSL.lists;
-import static org.quicktheories.generators.SourceDSL.strings;
+import static org.quicktheories.generators.SourceDSL.*;
 
 public class ArbitraryHttp {
   static Gen<String> htab() {
@@ -59,9 +58,9 @@ public class ArbitraryHttp {
   public static Gen<String> hosts(int length) {
     return alphanumeric(length/2)
         .zip(constant("-").toOptionals(10),
-        alphanumeric(length/2),
-        (prefix, optDash, suffix) ->
-          prefix + optDash.orElse("") + suffix
+             alphanumeric(length/2),
+             (prefix, optDash, suffix) ->
+                 prefix + optDash.orElse("") + suffix
         );
   }
 
@@ -72,14 +71,14 @@ public class ArbitraryHttp {
     // hard-coding mix of unreserved & alphanumeric characters
     Gen<Optional<String>> rest =
         alphanumeric(length/2 - 3)
-        .mix(unreservedCharacters(3))
-        .mix(constant("/"))
-        .toOptionals(50);
+            .mix(unreservedCharacters(3))
+            .mix(constant("/"))
+            .toOptionals(50);
     return root.zip(firstComponent, rest, (r, optFc, optRest) ->
-      r
-      + optFc.orElse("")
-      // only include "rest" of the path if first component is present
-      + optRest.flatMap(res -> optFc.isPresent() ? Optional.of(res) : Optional.empty()).orElse("")
+        r
+        + optFc.orElse("")
+        // only include "rest" of the path if first component is present
+        + optRest.flatMap(res -> optFc.isPresent() ? Optional.of(res) : Optional.empty()).orElse("")
     );
   }
 
@@ -88,26 +87,42 @@ public class ArbitraryHttp {
     return oneOf(constant("http"), constant("https"));
   }
 
-  public static final Gen<URI> requestTargets() {
+  public static Gen<URI> requestTargets() {
     return schemes().toOptionals(10).zip(hosts(10),
-                         paths(10).toOptionals(20),
-                         (scheme, host, optPath) -> {
-      try {
-        return new URI(scheme.isPresent() ? scheme.get() : null,
-                       scheme.isPresent() ? host : null,
-                       optPath.orElse("/"),
-                       null);
-      } catch (URISyntaxException e) {
-        throw new RuntimeException("origin URI failed to generate valid URI", e);
-      }
-    });
+                                         paths(10).toOptionals(20),
+                                         (scheme, host, optPath) -> {
+                                           try {
+                                             return new URI(scheme.isPresent() ? scheme.get() : null,
+                                                            scheme.isPresent() ? host : null,
+                                                            optPath.orElse("/"),
+                                                            null);
+                                           } catch (URISyntaxException e) {
+                                             throw new RuntimeException("origin URI failed to generate valid URI", e);
+                                           }
+                                         });
   }
 
-  public static final Gen<String> httpVersions() {
+  public static Gen<String> httpVersions() {
     return pick(HttpVersion.allVersions);
   }
 
-  public static final Gen<Method> methods() {
+  public static Gen<Method> methods() {
     return enumValues(Method.class);
+  }
+
+  public static Gen<String> tokenChars() {
+    return pick(List.of("!", "#", "$", "%", "&", "'", "*", "+", "-", ".", "^", "_", "|", "~"));
+  }
+
+  public static Gen<String> optionalWhitespace() {
+    return strings().betweenCodePoints(' ', ' ').ofLengthBetween(0, 3);
+  }
+
+  public static Gen<Map<String, String>> headers() {
+    return maps()
+        .of(alphanumeric(32)
+                .mix(tokenChars(), 10),
+            alphanumeric(32))
+        .ofSizeBetween(1, 5);
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryHttp.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryHttp.java
@@ -28,8 +28,10 @@ public class ArbitraryHttp {
     return requests(methods(), requestTargets(), constant(HttpVersion.ONE_ONE));
   }
 
-  public static Gen<Request> requests(Gen<Method> methods, Gen<URI> uris, Gen<String> versions) {
-    return versions.zip(methods, uris, (v, m, u) -> new Request(v, m, u, null));
+  public static Gen<Request> requests(Gen<Method> methods,
+                                      Gen<URI> uris,
+                                      Gen<String> versions) {
+    return versions.zip(methods, uris, (v, m, u) -> new Request(v, m, u));
   }
 
   // !!!: all of these "length" args are rough approximations. proper DSL necessary

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerTests.java
@@ -92,7 +92,10 @@ public class HttpConnectionHandlerTests {
           HttpConnectionHandler handler = new HttpConnectionHandler(rs);
           rs.forEach(r ->
                          assertThat(
-                             handler.responseTo(new Request(HttpVersion.ONE_ONE, r.targetMethod, r.targetURI)),
+                             handler.responseTo(new Request(HttpVersion.ONE_ONE,
+                                                            r.targetMethod,
+                                                            r.targetURI,
+                                                            null)),
                              equalTo(r.response)
                          ));
         });

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerTests.java
@@ -94,8 +94,7 @@ public class HttpConnectionHandlerTests {
                          assertThat(
                              handler.responseTo(new Request(HttpVersion.ONE_ONE,
                                                             r.targetMethod,
-                                                            r.targetURI,
-                                                            null)),
+                                                            r.targetURI)),
                              equalTo(r.response)
                          ));
         });

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -2,10 +2,11 @@ package com.eighthlight.fabrial.test.http;
 
 import com.eighthlight.fabrial.http.request.HttpHeaderReader;
 import com.eighthlight.fabrial.utils.Result;
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ public class HttpHeaderReaderTest {
     return lineBuilder.toString();
   }
 
-  public static InputStream sourceFromString(String str) {
+  public static ByteArrayInputStream sourceFromString(String str) {
     return new ByteArrayInputStream(str.getBytes());
   }
 
@@ -109,7 +110,7 @@ public class HttpHeaderReaderTest {
     var headers = headerReader.readHeaders();
 
     assertThat(headers, is(Map.of("Accept", "*/*")));
-    assertThat(IOUtils.toString(source), is("body"));
+    assertThat(new String(source.readAllBytes()), is("body"));
   }
 
   @Test

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -66,7 +66,7 @@ public class HttpHeaderReaderTest {
     var headerReader = new HttpHeaderReader(new ByteArrayInputStream(
         ("foo:" + CRLF).getBytes()));
     var headers = headerReader.readHeaders();
-    assertThat(headers, is(emptyMap()));
+    assertThat(headers, is(Map.of("foo", "")));
   }
 
   @Test

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -11,12 +11,13 @@ import static org.hamcrest.core.Is.is;
 
 public class HttpHeaderReaderTest {
   @Test
-  void parsesKeyOfHeaderLine() {
+  void parsesNameAndValueOfHeaderLine() {
     var headerLines =
         new ByteArrayInputStream(("Content-Type: text/plain" + CRLF).getBytes());
 
     var headerReader = new HttpHeaderReader(headerLines);
 
-    assertThat(headerReader.getKey(), is("Content-Type"));
+    assertThat(headerReader.getFieldName(), is("Content-Type"));
+    assertThat(headerReader.getFieldValue(), is("text/plain"));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -4,6 +4,7 @@ import com.eighthlight.fabrial.http.request.HttpHeaderReader;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.util.List;
 
 import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,7 +18,23 @@ public class HttpHeaderReaderTest {
 
     var headerReader = new HttpHeaderReader(headerLines);
 
-    assertThat(headerReader.getFieldName(), is("Content-Type"));
-    assertThat(headerReader.getFieldValue(), is("text/plain"));
+    assertThat(headerReader.nextFieldName(), is("Content-Type"));
+    assertThat(headerReader.nextFieldValue(), is("text/plain"));
+  }
+
+  @Test
+  void multipleHeaders() {
+    var headerLines = String.join(CRLF, List.of(
+        "Content-Type: text/plain",
+        "Content-Length: 5"
+    ));
+
+    var headerReader = new HttpHeaderReader(new ByteArrayInputStream(headerLines.getBytes()));
+
+    assertThat(headerReader.nextFieldName(), is("Content-Type"));
+    assertThat(headerReader.nextFieldValue(), is("text/plain"));
+    headerReader.skipToNextLine();
+    assertThat(headerReader.nextFieldName(), is("Content-Length"));
+    assertThat(headerReader.nextFieldValue(), is("5"));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -5,10 +5,7 @@ import com.eighthlight.fabrial.utils.Result;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.*;
 import java.util.List;
 import java.util.Map;
 
@@ -36,13 +33,13 @@ public class HttpHeaderReaderTest {
     return lineBuilder.toString();
   }
 
-  public static Reader sourceFromString(String str) {
-    return new InputStreamReader(new ByteArrayInputStream(str.getBytes()));
+  public static InputStream sourceFromString(String str) {
+    return new ByteArrayInputStream(str.getBytes());
   }
 
   @Test
   void parsesNameAndValueOfHeaderLine() throws IOException {
-    var headerLines = sourceFromString("Content-Type: text/plain" + CRLF + CRLF);
+    InputStream headerLines = sourceFromString("Content-Type: text/plain" + CRLF + CRLF);
 
     var headerReader = new HttpHeaderReader(headerLines);
 
@@ -107,7 +104,7 @@ public class HttpHeaderReaderTest {
   void doesNotConsumeEntireStream() throws IOException {
     var headerLines =
         "Accept: */*" + CRLF + CRLF + "body";
-    var source = sourceFromString(headerLines);
+    InputStream source = sourceFromString(headerLines);
     var headerReader = new HttpHeaderReader(source);
     var headers = headerReader.readHeaders();
 

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -54,6 +54,30 @@ public class HttpHeaderReaderTest {
   }
 
   @Test
+  void missingFieldName() {
+    var headerReader = new HttpHeaderReader(new ByteArrayInputStream(
+        (": foo" + CRLF).getBytes()));
+    var headers = headerReader.readHeaders();
+    assertThat(headers, is(emptyMap()));
+  }
+
+  @Test
+  void missingFieldValue() {
+    var headerReader = new HttpHeaderReader(new ByteArrayInputStream(
+        ("foo:" + CRLF).getBytes()));
+    var headers = headerReader.readHeaders();
+    assertThat(headers, is(emptyMap()));
+  }
+
+  @Test
+  void allWhitespace() {
+    var headerReader = new HttpHeaderReader(new ByteArrayInputStream(
+        (" :   " + CRLF).getBytes()));
+    var headers = headerReader.readHeaders();
+    assertThat(headers, is(emptyMap()));
+  }
+
+  @Test
   void arbitraryHeaderLines() {
     qt().forAll(headers(), optionalWhitespace(), optionalWhitespace())
         .asWithPrecursor((headers, ows1, ows2) -> {

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -48,19 +48,21 @@ public class HttpHeaderReaderTest {
   @Test
   void arbitraryHeaderLines() {
     qt().forAll(headers(), optionalWhitespace(), optionalWhitespace())
-        .checkAssert((headers, ows1, ows2) -> {
-      var lineBuilder = new StringBuilder();
-      for (var entry: headers.entrySet()) {
-        lineBuilder.append(entry.getKey());
-        lineBuilder.append(":");
-        lineBuilder.append(ows1);
-        lineBuilder.append(entry.getValue());
-        lineBuilder.append(ows2);
-        lineBuilder.append(CRLF);
-      }
-      var headerLines = lineBuilder.toString();
-      var reader = new HttpHeaderReader(new ByteArrayInputStream(headerLines.getBytes()));
-      assertThat(reader.readHeaders(), is(headers));
-    });
+        .asWithPrecursor((headers, ows1, ows2) -> {
+          var lineBuilder = new StringBuilder();
+          for (var entry : headers.entrySet()) {
+            lineBuilder.append(entry.getKey());
+            lineBuilder.append(":");
+            lineBuilder.append(ows1);
+            lineBuilder.append(entry.getValue());
+            lineBuilder.append(ows2);
+            lineBuilder.append(CRLF);
+          }
+          return lineBuilder.toString();
+        })
+        .checkAssert((headers, ows1, ows2, headerLines) -> {
+          var reader = new HttpHeaderReader(new ByteArrayInputStream(headerLines.getBytes()));
+          assertThat(reader.readHeaders(), is(headers));
+        });
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
+import java.util.Map;
 
 import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,17 +25,20 @@ public class HttpHeaderReaderTest {
 
   @Test
   void multipleHeaders() {
-    var headerLines = String.join(CRLF, List.of(
-        "Content-Type: text/plain",
-        "Content-Length: 5"
-    ));
+    var headerLines =
+        String.join(CRLF, List.of(
+            "Content-Type: text/plain; charset=utf-8",
+            "Content-Length: 5"
+        ))
+        // add newline which would precede the request body
+        + CRLF;
 
     var headerReader = new HttpHeaderReader(new ByteArrayInputStream(headerLines.getBytes()));
-
-    assertThat(headerReader.nextFieldName(), is("Content-Type"));
-    assertThat(headerReader.nextFieldValue(), is("text/plain"));
-    headerReader.skipToNextLine();
-    assertThat(headerReader.nextFieldName(), is("Content-Length"));
-    assertThat(headerReader.nextFieldValue(), is("5"));
+    var headers = headerReader.readHeaders();
+    assertThat(headers,
+              is(Map.of(
+                  "Content-Type", "text/plain; charset=utf-8",
+                  "Content-Length", "5"
+              )));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -1,0 +1,22 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.request.HttpHeaderReader;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class HttpHeaderReaderTest {
+  @Test
+  void parsesKeyOfHeaderLine() {
+    var headerLines =
+        new ByteArrayInputStream(("Content-Type: text/plain" + CRLF).getBytes());
+
+    var headerReader = new HttpHeaderReader(headerLines);
+
+    assertThat(headerReader.getKey(), is("Content-Type"));
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 import static com.eighthlight.fabrial.test.http.ArbitraryHttp.headers;
 import static com.eighthlight.fabrial.test.http.ArbitraryHttp.optionalWhitespace;
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.quicktheories.QuickTheory.qt;
@@ -39,10 +40,17 @@ public class HttpHeaderReaderTest {
     var headerReader = new HttpHeaderReader(new ByteArrayInputStream(headerLines.getBytes()));
     var headers = headerReader.readHeaders();
     assertThat(headers,
-              is(Map.of(
-                  "Content-Type", "text/plain; charset=utf-8",
-                  "Content-Length", "5"
-              )));
+               is(Map.of(
+                   "Content-Type", "text/plain; charset=utf-8",
+                   "Content-Length", "5"
+               )));
+  }
+
+  @Test
+  void noHeaders() {
+    var headerReader = new HttpHeaderReader(new ByteArrayInputStream(CRLF.getBytes()));
+    var headers = headerReader.readHeaders();
+    assertThat(headers, is(emptyMap()));
   }
 
   @Test

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpHeaderReaderTest.java
@@ -16,6 +16,21 @@ import static org.hamcrest.core.Is.is;
 import static org.quicktheories.QuickTheory.qt;
 
 public class HttpHeaderReaderTest {
+  public static String headerLineFromComponents(Map<String, String> headers,
+                                                String ows1,
+                                                String ows2) {
+    var lineBuilder = new StringBuilder();
+    for (var entry : headers.entrySet()) {
+      lineBuilder.append(entry.getKey());
+      lineBuilder.append(":");
+      lineBuilder.append(ows1);
+      lineBuilder.append(entry.getValue());
+      lineBuilder.append(ows2);
+      lineBuilder.append(CRLF);
+    }
+    return lineBuilder.toString();
+  }
+
   @Test
   void parsesNameAndValueOfHeaderLine() {
     var headerLines =
@@ -80,18 +95,7 @@ public class HttpHeaderReaderTest {
   @Test
   void arbitraryHeaderLines() {
     qt().forAll(headers(), optionalWhitespace(), optionalWhitespace())
-        .asWithPrecursor((headers, ows1, ows2) -> {
-          var lineBuilder = new StringBuilder();
-          for (var entry : headers.entrySet()) {
-            lineBuilder.append(entry.getKey());
-            lineBuilder.append(":");
-            lineBuilder.append(ows1);
-            lineBuilder.append(entry.getValue());
-            lineBuilder.append(ows2);
-            lineBuilder.append(CRLF);
-          }
-          return lineBuilder.toString();
-        })
+        .asWithPrecursor(HttpHeaderReaderTest::headerLineFromComponents)
         .checkAssert((headers, ows1, ows2, headerLines) -> {
           var reader = new HttpHeaderReader(new ByteArrayInputStream(headerLines.getBytes()));
           assertThat(reader.readHeaders(), is(headers));

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpLineReaderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpLineReaderTest.java
@@ -1,0 +1,83 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.utils.HttpLineReader;
+import com.eighthlight.fabrial.utils.Result;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
+
+import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.Generate.constant;
+import static org.quicktheories.generators.SourceDSL.lists;
+import static org.quicktheories.generators.SourceDSL.strings;
+
+public class HttpLineReaderTest {
+  @ParameterizedTest
+  @ValueSource(strings = {"", CRLF})
+  void returnsEmptyString(String empty) {
+    var codePoints = empty.codePoints().toArray();
+    var buffer = ByteBuffer.allocate(codePoints.length * 4);
+    buffer.asIntBuffer().put(codePoints);
+    var bais = new ByteArrayInputStream(buffer.array());
+    var readBytes =
+        Result.attempt(new HttpLineReader(bais)::readLine)
+              .orElseAssert()
+              .codePoints()
+              .toArray();
+    var readLine = new String(readBytes, 0, readBytes.length);
+    assertThat(readLine, is(emptyString()));
+  }
+
+  @Test
+  void returnsLineWithoutCRLF() {
+    qt().forAll(strings().allPossible().ofLengthBetween(0, 32),
+                constant(CRLF).toOptionals(20))
+        .assuming((s, optCRLF) -> !s.contains(CRLF))
+        .checkAssert((s, optCRLF) -> {
+          var combined = optCRLF.map(c -> s + c).orElse(s);
+          var codePoints = combined.codePoints().toArray();
+          var buffer = ByteBuffer.allocate(codePoints.length * 4);
+          buffer.asIntBuffer().put(codePoints);
+          var bais = new ByteArrayInputStream(buffer.array());
+          var readBytes =
+              Result.attempt(new HttpLineReader(bais)::readLine)
+                    .orElseAssert()
+                    .codePoints()
+                    .toArray();
+          var readLine = new String(readBytes, 0, readBytes.length);
+          assertThat(readLine, equalTo(s));
+        });
+  }
+
+  @Test
+  void readsLines() {
+    qt().forAll(lists().of(strings().allPossible()
+                                    .ofLengthBetween(0, 32))
+                       .ofSizeBetween(0, 5))
+        .checkAssert(lines -> {
+          var joinedLines = String.join(CRLF, lines);
+          var codePoints = joinedLines.codePoints().toArray();
+          var buffer = ByteBuffer.allocate(codePoints.length * 4);
+          buffer.asIntBuffer().put(codePoints);
+          var bais = new ByteArrayInputStream(buffer.array());
+
+          for (var line: lines) {
+            var readBytes =
+                Result.attempt(new HttpLineReader(bais)::readLine)
+                      .orElseAssert()
+                      .codePoints()
+                      .toArray();
+            var readLine = new String(readBytes, 0, readBytes.length);
+            assertThat(readLine, equalTo(line));
+          }
+        });
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestLineParsingTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestLineParsingTests.java
@@ -36,15 +36,21 @@ public class HttpRequestLineParsingTests {
     return pick(List.of("0.8", "2.6", "0.0"));
   }
 
+  public static String concatRequestLineComponents(
+      String method,
+      String uri,
+      String version) {
+    return method + " "
+           + uri + " "
+           + "HTTP/" + version
+           + CRLF;
+  }
+
   public static ByteArrayInputStream requestLineFromComponents(
       String method,
       String uri,
       String version) {
-    String requestLine = method + " "
-                         + uri + " "
-                         + "HTTP/" + version
-                         + CRLF;
-    return new ByteArrayInputStream(requestLine.getBytes(StandardCharsets.UTF_8));
+    return new ByteArrayInputStream(concatRequestLineComponents(method, uri, version).getBytes());
   }
 
   @Test

--- a/src/test/java/com/eighthlight/fabrial/test/http/RequestBodyParsingTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/RequestBodyParsingTest.java
@@ -1,0 +1,53 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.request.RequestBuilder;
+import com.eighthlight.fabrial.http.request.RequestReader;
+import com.eighthlight.fabrial.utils.Result;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static com.eighthlight.fabrial.test.http.ArbitraryHttp.headers;
+import static com.eighthlight.fabrial.test.http.ArbitraryHttp.requests;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.strings;
+
+public class RequestBodyParsingTest {
+  @Test
+  void parsesRequestWithHeader() {
+    qt().forAll(requests(), headers(), strings().allPossible().ofLengthBetween(1, 32))
+        .checkAssert((request, headers, body) -> {
+          var requestLine = HttpRequestLineParsingTests.concatRequestLineComponents(
+              request.method.name(),
+              request.uri.toString(),
+              request.version);
+          var headerLines =
+              HttpHeaderReaderTest.headerLineFromComponents(headers, "","");
+          var requestMessage = requestLine + headerLines + body;
+          var requestReader = new RequestReader(new ByteArrayInputStream(requestMessage.getBytes()));
+
+          var parsedRequest = Result.attempt(requestReader::readRequest).orElseAssert();
+
+          assertThat(parsedRequest,
+                     equalTo(new RequestBuilder()
+                                 .withVersion(request.version)
+                                 .withMethod(request.method)
+                                 .withUri(request.uri)
+                                 .withHeaders(headers)
+                                 .build()));
+
+          assertThat(parsedRequest.body, notNullValue());
+
+          var baos = new ByteArrayOutputStream();
+          Result.attempt(() -> parsedRequest.body.transferTo(baos)).orElseAssert();
+          var requestBody = baos.toString(StandardCharsets.UTF_8);
+          
+          assertThat(requestBody, equalTo(body));
+        });
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/RequestBodyParsingTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/RequestBodyParsingTest.java
@@ -1,5 +1,7 @@
 package com.eighthlight.fabrial.test.http;
 
+import com.eighthlight.fabrial.http.HttpVersion;
+import com.eighthlight.fabrial.http.Method;
 import com.eighthlight.fabrial.http.request.RequestBuilder;
 import com.eighthlight.fabrial.http.request.RequestReader;
 import com.eighthlight.fabrial.utils.Result;
@@ -7,47 +9,118 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.eighthlight.fabrial.test.http.ArbitraryHttp.headers;
 import static com.eighthlight.fabrial.test.http.ArbitraryHttp.requests;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.strings;
 
 public class RequestBodyParsingTest {
   @Test
-  void parsesRequestWithHeader() {
-    qt().forAll(requests(), headers(), strings().allPossible().ofLengthBetween(1, 32))
-        .checkAssert((request, headers, body) -> {
-          var requestLine = HttpRequestLineParsingTests.concatRequestLineComponents(
-              request.method.name(),
-              request.uri.toString(),
-              request.version);
-          var headerLines =
-              HttpHeaderReaderTest.headerLineFromComponents(headers, "","");
-          var requestMessage = requestLine + headerLines + body;
-          var requestReader = new RequestReader(new ByteArrayInputStream(requestMessage.getBytes()));
+  void omitsBodyWhenContentLengthMissing() throws IOException {
+    var body = "foo";
+    var request = new RequestBuilder()
+        .withVersion(HttpVersion.ONE_ONE)
+        .withMethod(Method.PUT)
+        .withUriString("/foo")
+        .withBody(new ByteArrayInputStream(body.getBytes()))
+        .build();
 
+    var requestOS = new ByteArrayOutputStream();
+    new RequestWriter(requestOS).writeRequest(request);
+
+    var serializedRequest = new String(requestOS.toByteArray());
+
+    var requestReader = new RequestReader(new ByteArrayInputStream(serializedRequest.getBytes()));
+    var parsedRequest = Result.attempt(requestReader::readRequest).orElseAssert();
+
+    assertThat(parsedRequest, equalTo(request));
+
+    assertThat(parsedRequest.body, is(nullValue()));;
+  }
+
+  @Test
+  void parsesPUTRequest() throws IOException {
+    var body = "foo";
+    var bodyData = body.getBytes(StandardCharsets.UTF_8);
+    var bodyLength = bodyData.length;
+    var request = new RequestBuilder()
+        .withVersion(HttpVersion.ZERO_NINE)
+        .withMethod(Method.GET)
+        .withHeaders(Map.of(
+            "Content-Type", "text/plain",
+            "Content-Length", Integer.toString(bodyLength)
+        ))
+        .withUriString("/")
+        .withBody(new ByteArrayInputStream(bodyData))
+        .build();
+
+    var requestOS = new ByteArrayOutputStream();
+    new RequestWriter(requestOS).writeRequest(request);
+
+    var serializedRequest = new String(requestOS.toByteArray());
+
+    var requestReader = new RequestReader(new ByteArrayInputStream(serializedRequest.getBytes()));
+    var parsedRequest = Result.attempt(requestReader::readRequest).orElseAssert();
+
+    assertThat(parsedRequest, equalTo(request));
+
+    assertThat(parsedRequest.body, notNullValue());
+
+    assertThat(new String(parsedRequest.body.readAllBytes(),
+                          StandardCharsets.UTF_8),
+               equalTo(body));
+  }
+
+  @Test
+  void parsesRequestWithHeaderAndBody() {
+    qt().forAll(requests(), headers(), strings().allPossible().ofLengthBetween(1, 32))
+        .checkAssert((emptyRequest, headers, body) -> {
+          var headersWithBodyFields = new HashMap<>(headers);
+          var bodyChars = body.codePoints().toArray();
+          var bodyByteBuffer = ByteBuffer.allocate(bodyChars.length * 4);
+          bodyByteBuffer.asIntBuffer().put(bodyChars);
+          var bodyData = bodyByteBuffer.array();
+          headersWithBodyFields.putAll(Map.of(
+              "Content-Type", "text/plain",
+              "Content-Length", Integer.toString(bodyData.length)
+          ));
+          // reassemble request w/ headers & body
+          final var request = new RequestBuilder()
+              .withVersion(emptyRequest.version)
+              .withMethod(emptyRequest.method)
+              .withUri(emptyRequest.uri)
+              .withBody(new ByteArrayInputStream(bodyData))
+              .withHeaders(headersWithBodyFields)
+              .build();
+
+          // write request to bytes
+          var requestOS = new ByteArrayOutputStream();
+          Result.attempt(() -> new RequestWriter(requestOS).writeRequest(request)).orElseAssert();
+
+          // read request from bytes
+          var requestReader = new RequestReader(new ByteArrayInputStream(requestOS.toByteArray()));
           var parsedRequest = Result.attempt(requestReader::readRequest).orElseAssert();
 
-          assertThat(parsedRequest,
-                     equalTo(new RequestBuilder()
-                                 .withVersion(request.version)
-                                 .withMethod(request.method)
-                                 .withUri(request.uri)
-                                 .withHeaders(headers)
-                                 .build()));
-
+          assertThat(parsedRequest, equalTo(request));
           assertThat(parsedRequest.body, notNullValue());
 
-          var baos = new ByteArrayOutputStream();
-          Result.attempt(() -> parsedRequest.body.transferTo(baos)).orElseAssert();
-          var requestBody = baos.toString(StandardCharsets.UTF_8);
-          
-          assertThat(requestBody, equalTo(body));
+          var parsedBodyData =
+              Result.attempt(parsedRequest.body::readAllBytes)
+                    .map(ByteBuffer::wrap)
+                    .orElseAssert();
+          var intBuf = new int[bodyChars.length];
+          parsedBodyData.asIntBuffer().get(intBuf, 0 , bodyChars.length);
+          var parsedBody = new String(intBuf, 0 , intBuf.length);
+          assertThat(parsedBody,  equalTo(body));
         });
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/RequestHeaderParsingTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/RequestHeaderParsingTest.java
@@ -1,0 +1,41 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.request.RequestBuilder;
+import com.eighthlight.fabrial.http.request.RequestReader;
+import com.eighthlight.fabrial.utils.Result;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static com.eighthlight.fabrial.test.http.ArbitraryHttp.headers;
+import static com.eighthlight.fabrial.test.http.ArbitraryHttp.requests;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.quicktheories.QuickTheory.qt;
+
+public class RequestHeaderParsingTest {
+  @Test
+  void parsesRequestWithHeader() {
+    qt().forAll(requests(), headers())
+        .as((req, headers) -> {
+          return new RequestBuilder()
+              .withVersion(req.version)
+              .withMethod(req.method)
+              .withUri(req.uri)
+              .withHeaders(headers)
+              .build();
+        })
+        .checkAssert((request) -> {
+          var requestLine = HttpRequestLineParsingTests.concatRequestLineComponents(
+              request.method.name(),
+              request.uri.toString(),
+              request.version);
+          var headerLines =
+              HttpHeaderReaderTest.headerLineFromComponents(request.headers, "","");
+          var requestMessage = requestLine + headerLines;
+          var requestReader = new RequestReader(new ByteArrayInputStream(requestMessage.getBytes()));
+          assertThat(Result.attempt(requestReader::readRequest).orElseAssert(),
+                     equalTo(request));
+        });
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/RequestWriter.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/RequestWriter.java
@@ -25,7 +25,9 @@ public class RequestWriter {
     writeHeaders(request);
     writer.write(CRLF);
     writer.flush();
-    request.body.transferTo(os);
+    if (request.body != null) {
+      request.body.transferTo(os);
+    }
   }
 
   public void writeRequestLine(Request request) throws IOException {
@@ -36,6 +38,9 @@ public class RequestWriter {
   }
 
   public void writeHeaders(Request request) throws IOException {
+    if (request.headers == null) {
+      return;
+    }
     for (var entry: request.headers.entrySet()) {
       writer.write(entry.getKey());
       writer.write(":");

--- a/src/test/java/com/eighthlight/fabrial/test/http/RequestWriter.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/RequestWriter.java
@@ -12,19 +12,35 @@ import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 
 public class RequestWriter {
   private final OutputStream os;
+  private final BufferedWriter writer;
 
   public RequestWriter(OutputStream os) {
     this.os = os;
+    this.writer = new BufferedWriter(new OutputStreamWriter(os));
   }
 
   public void writeRequest(Request request) throws IOException {
-    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(os));
+    writeRequestLine(request);
+    writer.write(CRLF);
+    writeHeaders(request);
+    writer.write(CRLF);
+    writer.flush();
+    request.body.transferTo(os);
+  }
+
+  public void writeRequestLine(Request request) throws IOException {
     List<String> requestLineComponents = List.of(request.method.name(),
                                                  request.uri.toString(),
                                                  "HTTP/" + request.version);
-    String line = String.join(" ", requestLineComponents)
-                  + CRLF;
-    writer.write(line);
-    writer.flush();
+    writer.write(String.join(" ", requestLineComponents));
+  }
+
+  public void writeHeaders(Request request) throws IOException {
+    for (var entry: request.headers.entrySet()) {
+      writer.write(entry.getKey());
+      writer.write(":");
+      writer.write(entry.getValue());
+      writer.write(CRLF);
+    }
   }
 }


### PR DESCRIPTION
> Prerequisite for implementing #33

There were a number of "gotchyas" that I had to overcome in this change:

To prevent request parsing from consuming the body data in the stream, I had to implement `HttpLineReader` which simply reads data 1 byte at a time from an input stream until a `CRLF` is encountered, at which point it returns the accumulated string with the trailing `CRLF` removed. It should also return any accumulated string data when encountering an EOF.

Lastly, I had a lot of trouble getting the property-based test for body parsing to pass. Ultimately, I needed to take extra care to serialize the input string's code points to a byte array, pass it unaltered to the request reader, and the recreate the string from the bytes converted to an int buffer representing the original code points.

I might do some additional cleanup & documentation, but this is ready to go.