### PR TITLE
Implement DELETE request

### DIFF
--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -175,7 +175,7 @@ public class FileHttpResponder implements HttpResponder {
       return builder.withStatusCode(411).build();
     } else if (contentLength.get().getError().isPresent()) {
       logger.trace("Failed to parse content length");
-      return builder.withStatusCode(400).build();
+      return builder.withStatusCode(411).build();
     }
 
     try {

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -192,8 +192,6 @@ public class FileHttpResponder implements HttpResponder {
   private Response buildDeleteResponse(Request request, ResponseBuilder builder) {
     try {
       fileController.removeFile(request.uri.getPath());
-    } catch (FileNotFoundException e) {
-      return builder.withStatusCode(404).build();
     } catch (IOException e) {
       return builder.withStatusCode(500)
                     .withReason(e.getMessage())

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -83,6 +83,9 @@ public class FileHttpResponder implements HttpResponder {
       case PUT: {
         return buildPutResponse(request, builder);
       }
+      case DELETE: {
+        return buildDeleteResponse(request, builder);
+      }
       default:
         return builder.withStatusCode(405).build();
     }
@@ -185,5 +188,9 @@ public class FileHttpResponder implements HttpResponder {
       // e.g. trying to PUT a directory or some such nonsense
       return builder.withStatusCode(400).withReason(e.getMessage()).build();
     }
+  }
+
+  private Response buildDeleteResponse(Request request, ResponseBuilder builder) {
+    return builder.withStatusCode(200).build();
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -11,10 +11,7 @@ import net.logstash.logback.argument.StructuredArguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +46,8 @@ public class FileHttpResponder implements HttpResponder {
     InputStream getFileContents(String relPathStr) throws IOException;
 
     void updateFileContents(String relPathStr, InputStream data, int length) throws IOException;
+
+    void removeFile(String relPathStr) throws IOException;
   }
 
   public FileHttpResponder(FileController fileController) {
@@ -191,6 +190,15 @@ public class FileHttpResponder implements HttpResponder {
   }
 
   private Response buildDeleteResponse(Request request, ResponseBuilder builder) {
+    try {
+      fileController.removeFile(request.uri.getPath());
+    } catch (FileNotFoundException e) {
+      return builder.withStatusCode(404).build();
+    } catch (IOException e) {
+      return builder.withStatusCode(500)
+                    .withReason(e.getMessage())
+                    .build();
+    }
     return builder.withStatusCode(200).build();
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/file/LocalFilesystemController.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/LocalFilesystemController.java
@@ -73,7 +73,10 @@ public class LocalFilesystemController implements FileHttpResponder.FileControll
   }
 
   @Override
-  public void removeFile(String relPathStr) {
-    absolutePathInBaseDir(relPathStr).toFile().delete();
+  public void removeFile(String relPathStr) throws IOException {
+    var deleted = absolutePathInBaseDir(relPathStr).toFile().delete();
+    if (!deleted) {
+      throw new IOException("Failed to delete file");
+    }
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/file/LocalFilesystemController.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/LocalFilesystemController.java
@@ -74,6 +74,6 @@ public class LocalFilesystemController implements FileHttpResponder.FileControll
 
   @Override
   public void removeFile(String relPathStr) {
-
+    absolutePathInBaseDir(relPathStr).toFile().delete();
   }
 }

--- a/src/main/java/com/eighthlight/fabrial/http/file/LocalFilesystemController.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/LocalFilesystemController.java
@@ -71,4 +71,9 @@ public class LocalFilesystemController implements FileHttpResponder.FileControll
       fileOutStream.write(buf.array(), 0, length);
     }
   }
+
+  @Override
+  public void removeFile(String relPathStr) {
+
+  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderDeleteTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderDeleteTest.java
@@ -34,4 +34,43 @@ public class FileHttpResponderDeleteTest {
 
     assertThat(mockFC.root.children, not(contains(file)));
   }
+
+  @Test
+  void deleteAbsentFile() {
+    var mockFC = new MockFileController();
+    var responder = new FileHttpResponder(mockFC);
+
+    mockFC.root = new MockDirectory("foo");
+
+    var response = responder.getResponse(
+        new RequestBuilder()
+            .withVersion(HttpVersion.ONE_ONE)
+            .withMethod(Method.DELETE)
+            .withUriString("bar")
+            .build());
+    assertThat(response.statusCode, is(404));
+    assertThat(response.headers, is(emptyMap()));
+  }
+
+  @Test
+  void deleteDirWithFiles() {
+    var mockFC = new MockFileController();
+    var responder = new FileHttpResponder(mockFC);
+
+    mockFC.root = new MockDirectory("foo");
+
+    var childDir = new MockDirectory("bar");
+    mockFC.root.children.add(childDir);
+
+    childDir.children.add(new MockFile("baz"));
+
+    var response = responder.getResponse(
+        new RequestBuilder()
+            .withVersion(HttpVersion.ONE_ONE)
+            .withMethod(Method.DELETE)
+            .withUriString("bar")
+            .build());
+    assertThat(response.statusCode, is(500));
+    assertThat(response.headers, is(emptyMap()));
+  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderDeleteTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderDeleteTest.java
@@ -1,0 +1,37 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.HttpVersion;
+import com.eighthlight.fabrial.http.Method;
+import com.eighthlight.fabrial.http.file.FileHttpResponder;
+import com.eighthlight.fabrial.http.request.RequestBuilder;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+public class FileHttpResponderDeleteTest {
+  @Test
+  void deleteFile() {
+    var mockFC = new MockFileController();
+    var responder = new FileHttpResponder(mockFC);
+
+    mockFC.root = new MockDirectory("foo");
+
+    var file = new MockFile("bar");
+    mockFC.root.children.add(file);
+
+    var response = responder.getResponse(
+        new RequestBuilder()
+            .withVersion(HttpVersion.ONE_ONE)
+            .withMethod(Method.DELETE)
+            .withUriString(file.getName())
+            .build());
+    assertThat(response.statusCode, is(200));
+    assertThat(response.headers, is(emptyMap()));
+
+    assertThat(mockFC.root.children, not(contains(file)));
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderPutTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderPutTest.java
@@ -36,6 +36,29 @@ public class FileHttpResponderPutTest {
   }
 
   @Test
+  void putWithInvalidContentLengthHeader() {
+    var mockFC = new MockFileController();
+    var responder = new FileHttpResponder(mockFC);
+
+    mockFC.root = new MockDirectory("foo");
+
+    var data = "buz".getBytes();
+
+    var response = responder.getResponse(
+        new RequestBuilder()
+            .withVersion(HttpVersion.ONE_ONE)
+            .withMethod(Method.PUT)
+            .withUriString("baz")
+            .withBody(new ByteArrayInputStream(data))
+            .withHeaders(Map.of(
+                "Content-Length", "fuz"
+            ))
+            .build());
+    assertThat(response.statusCode, is(411));
+    assertThat(response.headers, is(emptyMap()));
+  }
+
+  @Test
   void putCreateFile() {
     var mockFC = new MockFileController();
     var responder = new FileHttpResponder(mockFC);

--- a/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
@@ -222,7 +222,7 @@ public class LocalFilesystemControllerIntegrationTest {
   }
 
   @Test
-  void deletesExistingFiles() {
+  void deletesExistingFiles() throws IOException {
     try (var tmpFileFixture = new TempFileFixture()) {
       var fileController =
           new LocalFilesystemController(tmpFileFixture.tempFilePath.getParent());

--- a/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
@@ -254,4 +254,21 @@ public class LocalFilesystemControllerIntegrationTest {
       assertThat(childDirFixture.tempDirPath.toFile().exists(), is(false));
     }
   }
+
+  @Test
+  void deletesNestedFile() throws IOException {
+    try (var tmpDirFixture = new TempDirectoryFixture();
+        var childDirFixture = new TempDirectoryFixture(tmpDirFixture.tempDirPath);
+        var tmpFileFixture = new TempFileFixture(childDirFixture.tempDirPath)) {
+      var fileController =
+          new LocalFilesystemController(tmpDirFixture.tempDirPath);
+      var relFilePath =
+          tmpDirFixture
+              .tempDirPath
+              .relativize(tmpFileFixture.tempFilePath.toAbsolutePath())
+              .toString();
+      fileController.removeFile(relFilePath);
+      assertThat(tmpFileFixture.tempFilePath.toFile().exists(), is(false));
+    }
+  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
@@ -231,4 +231,17 @@ public class LocalFilesystemControllerIntegrationTest {
                  is(false));
     }
   }
+
+  @Test
+  void failsToDeleteDirectoriesWithFiles() {
+    try (var tmpDirFixture = new TempDirectoryFixture();
+        var tmpFileFixture = new TempFileFixture(tmpDirFixture.tempDirPath)) {
+      var fileController =
+          new LocalFilesystemController(tmpDirFixture.tempDirPath);
+      assertThrows(IOException.class, () -> {
+        fileController.removeFile("/");
+      });
+      assertThat(tmpDirFixture.tempDirPath.toFile().exists(), is(true));
+    }
+  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
@@ -227,8 +227,7 @@ public class LocalFilesystemControllerIntegrationTest {
       var fileController =
           new LocalFilesystemController(tmpFileFixture.tempFilePath.getParent());
       fileController.removeFile(tmpFileFixture.tempFilePath.getFileName().toString());
-      assertThat(tmpFileFixture.tempFilePath.toFile().exists(),
-                 is(false));
+      assertThat(tmpFileFixture.tempFilePath.toFile().exists(), is(false));
     }
   }
 
@@ -242,6 +241,17 @@ public class LocalFilesystemControllerIntegrationTest {
         fileController.removeFile("/");
       });
       assertThat(tmpDirFixture.tempDirPath.toFile().exists(), is(true));
+    }
+  }
+
+  @Test
+  void deletesEmptyDirectories() throws IOException {
+    try (var tmpDirFixture = new TempDirectoryFixture();
+        var childDirFixture = new TempDirectoryFixture(tmpDirFixture.tempDirPath)) {
+      var fileController =
+          new LocalFilesystemController(tmpDirFixture.tempDirPath);
+      fileController.removeFile(childDirFixture.tempDirPath.getFileName().toString());
+      assertThat(childDirFixture.tempDirPath.toFile().exists(), is(false));
     }
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/LocalFilesystemControllerIntegrationTest.java
@@ -220,4 +220,15 @@ public class LocalFilesystemControllerIntegrationTest {
       });
     }
   }
+
+  @Test
+  void deletesExistingFiles() {
+    try (var tmpFileFixture = new TempFileFixture()) {
+      var fileController =
+          new LocalFilesystemController(tmpFileFixture.tempFilePath.getParent());
+      fileController.removeFile(tmpFileFixture.tempFilePath.getFileName().toString());
+      assertThat(tmpFileFixture.tempFilePath.toFile().exists(),
+                 is(false));
+    }
+  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/MockFileController.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/MockFileController.java
@@ -8,6 +8,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -104,5 +106,23 @@ public class MockFileController implements FileHttpResponder.FileController {
     var buf = ByteBuffer.allocate(length);
     data.read(buf.array(), 0, length);
     file.data = buf.array();
+  }
+
+  @Override
+  public void removeFile(String relPathStr) throws IOException {
+    var file = fileAtPath(relPathStr);
+    if (!file.isPresent()) {
+      throw new FileNotFoundException("No file at path " + relPathStr);
+    }
+    var parentPath = Optional.ofNullable(Paths.get(relPathStr).getParent())
+                             .map(Path::toString)
+                             .orElse("");
+    var parent =
+        fileAtPath(parentPath)
+            .flatMap(p -> p.isDirectory() ? Optional.of((MockDirectory)p) : Optional.empty());
+    if (!parent.isPresent()) {
+      throw new FileNotFoundException("Parent not found at " + parentPath);
+    }
+    parent.get().children.remove(file.get());
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/MockFileController.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/MockFileController.java
@@ -114,6 +114,12 @@ public class MockFileController implements FileHttpResponder.FileController {
     if (!file.isPresent()) {
       throw new FileNotFoundException("No file at path " + relPathStr);
     }
+
+    if (file.get().isDirectory()
+        && !((MockDirectory)file.get()).children.isEmpty()) {
+      throw new IOException("Directory not empty");
+    }
+
     var parentPath = Optional.ofNullable(Paths.get(relPathStr).getParent())
                              .map(Path::toString)
                              .orElse("");

--- a/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/AppAcceptanceTest.java
@@ -255,4 +255,24 @@ public class AppAcceptanceTest {
       }
     }
   }
+
+  @Test
+  void deleteFile() throws IOException {
+    int testPort = 8082;
+    try (var tmpFileFixture = new TempFileFixture(Paths.get("/tmp"), ".txt");
+        AppProcessFixture appFixture = new AppProcessFixture(testPort, tmpFileFixture.tempFilePath.getParent().toString())) {
+      var responseLines =
+          sendRequest(new RequestBuilder()
+                          .withVersion(HttpVersion.ONE_ONE)
+                          .withMethod(Method.DELETE)
+                          .withUriString(tmpFileFixture.tempFilePath.getFileName().toString())
+                          .build(),
+                      testPort);
+      assertThat(responseLines, hasSize(1));
+      assertThat(responseLines.get(0),
+                 is("HTTP/1.1 200 "));
+
+      assertThat(tmpFileFixture.tempFilePath.toFile().exists(), is(false));
+    }
+  }
 }


### PR DESCRIPTION
> Resolves #32

Delete files & empty directories when receiving a `DELETE` request. Return 200 status code on success, 404 on not found, and 500 on failure to delete.