### PR TITLE
Refactor byte range parsing & add support for partial range specifiers

### DIFF
--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -131,6 +131,7 @@ public class FileHttpResponder implements HttpResponder {
             // return early with unsatisfiable range response
             return builder.withStatusCode(416)
                           .withHeader("Content-Range", "*/" + sizeInt)
+                          .withReason(e.getMessage())
                           .build();
           }
 

--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -112,7 +112,7 @@ public class FileHttpResponder implements HttpResponder {
       try {
         range = HttpRequestByteRange.parseFromHeader(rangeHeader, fileSizeInt);
       } catch (HttpRequestByteRange.ParsingException e) {
-        builder.withStatusCode(400);
+        builder.withStatusCode(416);
         return;
       }
 

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpRequestByteRange.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpRequestByteRange.java
@@ -120,6 +120,9 @@ public class HttpRequestByteRange {
     return last - first + 1;
   }
 
+  /**
+   * @return A string formatted for use in Content-Range response headers.
+   */
   public String toString() {
     return String.format("bytes %d-%d", first, last);
   }

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpRequestByteRange.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpRequestByteRange.java
@@ -85,11 +85,12 @@ public class HttpRequestByteRange {
     var last = parseRangeComponent(matcher.group(3), fileSize);
 
     if (first.isPresent() && last.isPresent()) {
-      if (first.get() > last.get()) {
-        throw new ParsingException("Last index of range must be greater than the first.");
+      try {
+        // return range w/ desired first & last positions (e.g. "0-5")
+        return new HttpRequestByteRange(first.get(), last.get());
+      } catch (IllegalArgumentException e) {
+        throw new ParsingException(e);
       }
-      // return range w/ desired first & last positions (e.g. "0-5")
-      return new HttpRequestByteRange(first.get(), last.get());
     } else if (first.isPresent()) {
       // return range from desired first position to end of file (e.g. "5-")
       return new HttpRequestByteRange(first.get(), fileSize - 1);
@@ -102,6 +103,12 @@ public class HttpRequestByteRange {
   }
 
   public HttpRequestByteRange(int first, int last) {
+    if (first < 0) {
+      throw new IllegalArgumentException("First position must be greater than or equal to zero.");
+    }
+    if (last < first) {
+      throw new IllegalArgumentException("Last position cannot be less than the first.");
+    }
     this.first = first;
     this.last = last;
   }

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpRequestByteRange.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpRequestByteRange.java
@@ -1,0 +1,91 @@
+package com.eighthlight.fabrial.http.request;
+
+import com.eighthlight.fabrial.utils.Result;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class HttpRequestByteRange {
+  public final int first;
+  public final int last;
+
+  public static final class ParsingException extends Exception {
+    public ParsingException(String message) {
+      super(message);
+    }
+
+    public ParsingException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    public ParsingException(Throwable cause) {
+      super(cause);
+    }
+  }
+
+  private static final Pattern RANGE_PATTERN = Pattern.compile("([^=]+)=(\\d*)-(\\d*)");
+
+  public static HttpRequestByteRange parseFromHeader(
+      String headerValue,
+      int fileSize) throws ParsingException {
+    var matcher = RANGE_PATTERN.matcher(headerValue);
+    if (!matcher.find()) {
+      throw new ParsingException("Failed to match range components. Expected 'bytes=first?-last?'");
+    }
+
+    var unit = matcher.group(1);
+    if (!"bytes".equals(unit)) {
+      throw new ParsingException("Unacceptable range request unit: " + unit);
+    }
+
+    var first = Result.<String, NumberFormatException>of(
+        Optional
+            .ofNullable(matcher.group(2))
+            .flatMap(s -> s.isEmpty() ? Optional.empty() : Optional.of(s))
+            .orElse("0")
+    ).flatMapAttempt(Integer::parseInt)
+     .flatMap(i -> i < 0 || i > fileSize - 1 ? Result.failure(new ParsingException("Out of bounds first position")) : Result.success(i))
+     .orElseThrow();
+
+    var last = Result.<String, NumberFormatException>of(
+        Optional
+            .ofNullable(matcher.group(3))
+            .flatMap(s -> s.isEmpty() ? Optional.empty() : Optional.of(s))
+            .orElse(Integer.toString(fileSize - 1))
+    ).flatMapAttempt(Integer::parseInt)
+     .flatMap(i -> i < 0 || i > fileSize - 1 ? Result.failure(new ParsingException("Out of bounds last position")) : Result.success(i))
+     .orElseThrow();
+
+    return new HttpRequestByteRange(first, last);
+  }
+
+  public HttpRequestByteRange(int first, int last) {
+    this.first = first;
+    this.last = last;
+  }
+
+  public int length() {
+    return last - first + 1;
+  }
+
+  public String toString() {
+    return String.format("bytes %d-%d", first, last);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    HttpRequestByteRange that = (HttpRequestByteRange) o;
+    return first == that.first &&
+           last == that.last;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(first, last);
+  }
+}

--- a/src/main/java/com/eighthlight/fabrial/http/request/HttpRequestByteRange.java
+++ b/src/main/java/com/eighthlight/fabrial/http/request/HttpRequestByteRange.java
@@ -85,7 +85,7 @@ public class HttpRequestByteRange {
         // passing MAX to bypass fileSize checking
         parseRangeComponent(matcher.group(3), Integer.MAX_VALUE)
         // wrap to max index, see RFC 7233 section 2.1:
-        // "if the [suffix length] value is greater than or equal to the the length...the byte range
+        // "if the [suffix length] value is greater than or equal to the length...the byte range
         // is interpreted as the remainder of the representation"
         .map(l -> Integer.min(l, fileSize - 1));
 

--- a/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryByteRangeTest.java
@@ -1,0 +1,96 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.request.HttpRequestByteRange;
+import com.eighthlight.fabrial.utils.Result;
+import org.junit.jupiter.api.Test;
+import org.quicktheories.api.Pair;
+import org.quicktheories.api.Tuple3;
+import org.quicktheories.core.Gen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.integers;
+
+public class ArbitraryByteRangeTest {
+  private static Gen<Pair<Integer, Integer>> fileSizeAndPosition() {
+    return integers().from(1)
+                     .upToAndIncluding(Integer.MAX_VALUE - 1)
+                     .mutate((size, rand) -> {
+                       return Pair.of(size, integers().between(0, size - 1).generate(rand));
+                     });
+  }
+  private static Gen<Tuple3<Integer, Integer, Integer>> fileSizeFirstPosAndLastPos() {
+    return fileSizeAndPosition().mutate((sizeAndFirst, rand) -> {
+      var size = sizeAndFirst._1;
+      var first = sizeAndFirst._2;
+      return Tuple3.of(size, first, integers().between(first, size - 1).generate(rand));
+    });
+  }
+
+  @Test
+  void parsesAllValidRangesWithFirstAndLastPositions() {
+    qt().forAll(fileSizeFirstPosAndLastPos())
+        .checkAssert(t3 -> {
+          var size = t3._1;
+          var first = t3._2;
+          var last = t3._3;
+          var rangeHeader = String.format("bytes=%d-%d", first, last);
+          var range = Result
+              .attempt(() -> HttpRequestByteRange.parseFromHeader(rangeHeader, size))
+              .orElseAssert();
+          assertThat(range.first, is(first));
+          assertThat(range.last, is(last));
+          assertThat(range.length(), is(last - first + 1));
+        });
+  }
+
+  @Test
+  void failsToParseAllRangesWhereFirstGreaterThanLast() {
+    qt().forAll(fileSizeFirstPosAndLastPos())
+        // except ranges where first & last are equal, since they're equivalent to their inversions
+        .assuming(t3 -> !t3._2.equals(t3._3))
+        .checkAssert(t3 -> {
+          var size = t3._1;
+          var first = t3._2;
+          var last = t3._3;
+          // swap last & first, resulting in an invalid range
+          var rangeHeader = String.format("bytes=%d-%d", last, first);
+          assertThrows(HttpRequestByteRange.ParsingException.class,
+                       () -> HttpRequestByteRange.parseFromHeader(rangeHeader, size));
+        });
+  }
+
+  @Test
+  void parsesRangesWithValidFirstPosition() {
+    qt().forAll(fileSizeAndPosition())
+        .checkAssert(t2 -> {
+          var size = t2._1;
+          var first = t2._2;
+          var rangeHeader = String.format("bytes=%d-", first);
+          var range = Result
+              .attempt(() -> HttpRequestByteRange.parseFromHeader(rangeHeader, size))
+              .orElseAssert();
+          assertThat(range.first, is(first));
+          assertThat(range.last, is(size - 1));
+          assertThat(range.length(), is(size - first));
+        });
+  }
+
+  @Test
+  void parsesRangesWithValidLastPosition() {
+    qt().forAll(fileSizeAndPosition())
+        .checkAssert(t2 -> {
+          var size = t2._1;
+          var suffixLength = t2._2;
+          var rangeHeader = String.format("bytes=-%d", suffixLength);
+          var range = Result
+              .attempt(() -> HttpRequestByteRange.parseFromHeader(rangeHeader, size))
+              .orElseAssert();
+          assertThat(range.first, is(size - suffixLength));
+          assertThat(range.last, is(size - 1));
+          assertThat(range.length(), is(suffixLength));
+        });
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryByteRangeTest.java
@@ -82,9 +82,10 @@ public class ArbitraryByteRangeTest {
   @Test
   void parsesRangesWithValidLastPosition() {
     qt().forAll(fileSizeAndPosition())
-        .checkAssert(t2 -> {
-          var size = t2._1;
-          var suffixLength = t2._2;
+        .assuming(p -> p._2 > 0)
+        .checkAssert(p -> {
+          var size = p._1;
+          var suffixLength = p._2;
           var rangeHeader = String.format("bytes=-%d", suffixLength);
           var range = Result
               .attempt(() -> HttpRequestByteRange.parseFromHeader(rangeHeader, size))

--- a/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/ArbitraryByteRangeTest.java
@@ -7,6 +7,7 @@ import org.quicktheories.api.Pair;
 import org.quicktheories.api.Tuple3;
 import org.quicktheories.core.Gen;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -91,6 +92,31 @@ public class ArbitraryByteRangeTest {
           assertThat(range.first, is(size - suffixLength));
           assertThat(range.last, is(size - 1));
           assertThat(range.length(), is(suffixLength));
+        });
+  }
+
+  @Test
+  void rangesWithTheSameFirstAndLastPositionsAreEqual() {
+    qt().forAll(fileSizeFirstPosAndLastPos(), fileSizeFirstPosAndLastPos())
+        .checkAssert((t1, t2) -> {
+          var r1 = new HttpRequestByteRange(t1._2, t1._3);
+          var r2 = new HttpRequestByteRange(t2._2, t2._3);
+          assertThat(r1.equals(r2), equalTo(
+              r1.first == r2.first
+              && r1.last == r2.last
+          ));
+          assertThat(r1.equals(r2), equalTo(r1.hashCode() == r2.hashCode()));
+        });
+  }
+
+  @Test
+  void identicallyConstructedRangesAreEqual() {
+    qt().forAll(fileSizeFirstPosAndLastPos())
+        .checkAssert((t1) -> {
+          var r1 = new HttpRequestByteRange(t1._2, t1._3);
+          var r2 = new HttpRequestByteRange(t1._2, t1._3);
+          assertThat(r1, equalTo(r2));
+          assertThat(r1.hashCode(), equalTo(r2.hashCode()));
         });
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
@@ -140,6 +140,7 @@ public class FileHttpResponderGetTest {
             .withUriString(child.name)
             .build());
     assertThat(response.statusCode, is(416));
+    assertThat(response.reason, is("Out of bounds range component 10"));
     assertThat(response.headers, hasEntry("Content-Range", "*/" + child.data.length));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
@@ -140,7 +140,7 @@ public class FileHttpResponderGetTest {
             .withUriString(child.name)
             .build());
     assertThat(response.statusCode, is(416));
-    assertThat(response.reason, is("Out of bounds range component 10"));
+    assertThat(response.reason, containsString("Last position cannot be less than the first"));
     assertThat(response.headers, hasEntry("Content-Range", "*/" + child.data.length));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
@@ -89,7 +89,8 @@ public class FileHttpResponderGetTest {
     assertThat(response.headers, hasEntry("Content-Type", child.type));
     assertThat(response.headers, hasEntry("Content-Range", "bytes 0-1/" + child.data.length));
     assertThat(response.body, is(not(nullValue())));
-    assertThat(response.body.readAllBytes(), is(Arrays.copyOfRange(child.data, 0, 2)));
+    assertThat(new String(response.body.readAllBytes()),
+               is(new String(Arrays.copyOfRange(child.data, 0, 2))));
   }
 
   @Test

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
@@ -92,7 +92,31 @@ public class FileHttpResponderGetTest {
   }
 
   @Test
-  void responds500ReadError() throws IOException {
+  void sends500ResponseOnReadError() throws IOException {
+    var mockFC = new MockFileController() {
+      @Override
+      public InputStream getFileContents(String relPathStr, int offset, int length) throws IOException {
+        throw new IOException("test");
+      }
+    };
+    var responder = new FileHttpResponder(mockFC);
+
+    mockFC.root = new MockDirectory("foo");
+
+    // file must have data, otherwise we'll either get a 200 for an empty file response
+    var child = new MockFile("bar");
+    mockFC.root.children.add(child);
+    child.data = "foo".getBytes();
+    child.type = "text/plain";
+
+    var response = responder.getResponse(
+        new RequestBuilder()
+            .withVersion(HttpVersion.ONE_ONE)
+            .withMethod(Method.GET)
+            .withUriString(child.name)
+            .build());
+    assertThat(response.statusCode, is(500));
+  }
     var mockFC = new MockFileController();
     var responder = new FileHttpResponder(mockFC);
 

--- a/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/FileHttpResponderGetTest.java
@@ -7,6 +7,7 @@ import com.eighthlight.fabrial.http.request.RequestBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -117,6 +118,9 @@ public class FileHttpResponderGetTest {
             .build());
     assertThat(response.statusCode, is(500));
   }
+
+  @Test
+  void respondsToInvalidRangeWith416() {
     var mockFC = new MockFileController();
     var responder = new FileHttpResponder(mockFC);
 
@@ -131,9 +135,10 @@ public class FileHttpResponderGetTest {
         new RequestBuilder()
             .withVersion(HttpVersion.ONE_ONE)
             .withMethod(Method.GET)
-            .withHeaders(Map.of("Range", "bytes=0-10"))
+            .withHeaders(Map.of("Range", "bytes=10-0"))
             .withUriString(child.name)
             .build());
-    assertThat(response.statusCode, is(500));
+    assertThat(response.statusCode, is(416));
+    assertThat(response.headers, hasEntry("Content-Range", "*/" + child.data.length));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
@@ -45,21 +45,9 @@ public class HttpRequestByteRangeTest {
   }
 
   @Test
-  void failsToParseLastIndexWhichExceedsSize() {
-    assertThrows(HttpRequestByteRange.ParsingException.class,
-                 () -> HttpRequestByteRange.parseFromHeader("bytes=0-2", 1));
-  }
-
-  @Test
   void failsToParseFirstIndexGreaterThanLastIndex() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
                  () -> HttpRequestByteRange.parseFromHeader("bytes=1-0", 1));
-  }
-
-  @Test
-  void failsToParseRangeLargerThanSize() {
-    assertThrows(HttpRequestByteRange.ParsingException.class,
-                 () -> HttpRequestByteRange.parseFromHeader("bytes=0-1", 1));
   }
 
   @Test
@@ -117,5 +105,13 @@ public class HttpRequestByteRangeTest {
   @Test
   void formatsFirstAndLastInRange() {
     assertThat(new HttpRequestByteRange(0, 1).toString(), is("bytes 0-1"));
+  }
+
+  @Test
+  void wrapsRangesToFileLength() throws HttpRequestByteRange.ParsingException {
+    var range = HttpRequestByteRange.parseFromHeader("bytes=0-5", 2);
+    assertThat(range.first, is(0));
+    assertThat(range.last, is(1));
+    assertThat(range.length(), is(2));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
@@ -11,25 +11,25 @@ public class HttpRequestByteRangeTest {
   @Test
   void failsToParseEmptyString() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
-                 () -> HttpRequestByteRange.parseFromHeader("", 0));
+                 () -> HttpRequestByteRange.parseFromHeader("", 1));
   }
 
   @Test
   void failsToParseUnitsOtherThanBytes() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
-                 () -> HttpRequestByteRange.parseFromHeader("bits=0-0", 0));
+                 () -> HttpRequestByteRange.parseFromHeader("bits=0-0", 1));
   }
 
   @Test
   void failsToParseEmptyRange() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
-                 () -> HttpRequestByteRange.parseFromHeader("bytes=-", 0));
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=-", 1));
   }
 
   @Test
   void failsToParseNegativeFirstIndex() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
-                 () -> HttpRequestByteRange.parseFromHeader("bytes=-1-", 0));
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=-1-", 1));
   }
 
   @Test
@@ -41,7 +41,7 @@ public class HttpRequestByteRangeTest {
   @Test
   void failsToParseNegativeLastIndex() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
-                 () -> HttpRequestByteRange.parseFromHeader("bytes=0--1", 0));
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=0--1", 1));
   }
 
   @Test
@@ -60,6 +60,12 @@ public class HttpRequestByteRangeTest {
   void failsToParseRangeLargerThanSize() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
                  () -> HttpRequestByteRange.parseFromHeader("bytes=0-1", 1));
+  }
+
+  @Test
+  void failsToParseEmptySuffixRange() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("-0", 1));
   }
 
   @Test

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class HttypRequestByteRangeTest {
+public class HttpRequestByteRangeTest {
   @Test
   void failsToParseEmptyString() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
@@ -79,10 +79,18 @@ public class HttypRequestByteRangeTest {
   }
 
   @Test
-  void parsesRangeWithoutStart() throws HttpRequestByteRange.ParsingException {
-    var range = HttpRequestByteRange.parseFromHeader("bytes=-1", 5);
+  void parsesRangeWithoutFirstIndex() throws HttpRequestByteRange.ParsingException {
+    var range = HttpRequestByteRange.parseFromHeader("bytes=-2", 5);
     assertThat(range.first, is(3));
     assertThat(range.last, is(4));
-    assertThat(range.length(), is(1));
+    assertThat(range.length(), is(2));
+  }
+
+  @Test
+  void parsesRangeWithoutLastIndex() throws HttpRequestByteRange.ParsingException {
+    var range = HttpRequestByteRange.parseFromHeader("bytes=2-", 5);
+    assertThat(range.first, is(2));
+    assertThat(range.last, is(4));
+    assertThat(range.length(), is(3));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
@@ -3,8 +3,8 @@ package com.eighthlight.fabrial.test.http;
 import com.eighthlight.fabrial.http.request.HttpRequestByteRange;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HttpRequestByteRangeTest {
@@ -92,5 +92,19 @@ public class HttpRequestByteRangeTest {
     assertThat(range.first, is(2));
     assertThat(range.last, is(4));
     assertThat(range.length(), is(3));
+  }
+
+  @Test
+  void throwsWhenInitializedWithInvalidFirstPosition() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      new HttpRequestByteRange(-1, 0);
+    });
+  }
+
+  @Test
+  void throwsWhenFirstGreaterThanLast() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      new HttpRequestByteRange(1, 0);
+    });
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpRequestByteRangeTest.java
@@ -107,4 +107,9 @@ public class HttpRequestByteRangeTest {
       new HttpRequestByteRange(1, 0);
     });
   }
+
+  @Test
+  void formatsFirstAndLastInRange() {
+    assertThat(new HttpRequestByteRange(0, 1).toString(), is("bytes 0-1"));
+  }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttypRequestByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttypRequestByteRangeTest.java
@@ -1,0 +1,88 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.request.HttpRequestByteRange;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HttypRequestByteRangeTest {
+  @Test
+  void failsToParseEmptyString() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("", 0));
+  }
+
+  @Test
+  void failsToParseUnitsOtherThanBytes() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bits=0-0", 0));
+  }
+
+  @Test
+  void failsToParseEmptyRange() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=-", 0));
+  }
+
+  @Test
+  void failsToParseNegativeFirstIndex() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=-1-", 0));
+  }
+
+  @Test
+  void failsToParseFirstIndexWhichExceedsSize() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=2-", 1));
+  }
+
+  @Test
+  void failsToParseNegativeLastIndex() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=0--1", 0));
+  }
+
+  @Test
+  void failsToParseLastIndexWhichExceedsSize() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=0-2", 1));
+  }
+
+  @Test
+  void failsToParseFirstIndexGreaterThanLastIndex() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=1-0", 1));
+  }
+
+  @Test
+  void failsToParseRangeLargerThanSize() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=0-1", 1));
+  }
+
+  @Test
+  void parsesRangeWithFirstAndLast() throws HttpRequestByteRange.ParsingException {
+    var range = HttpRequestByteRange.parseFromHeader("bytes=0-1", 2);
+    assertThat(range.first, is(0));
+    assertThat(range.last, is(1));
+    assertThat(range.length(), is(2));
+  }
+
+  @Test
+  void parsesSingleByteRange() throws HttpRequestByteRange.ParsingException {
+    var range = HttpRequestByteRange.parseFromHeader("bytes=0-0", 2);
+    assertThat(range.first, is(0));
+    assertThat(range.last, is(0));
+    assertThat(range.length(), is(1));
+  }
+
+  @Test
+  void parsesRangeWithoutStart() throws HttpRequestByteRange.ParsingException {
+    var range = HttpRequestByteRange.parseFromHeader("bytes=-1", 5);
+    assertThat(range.first, is(3));
+    assertThat(range.last, is(4));
+    assertThat(range.length(), is(1));
+  }
+}


### PR DESCRIPTION
> Resolves #46, #47, & #48 

Using a separate class, pull out the individual parts of the range, handling all the cases when they are/aren't present and transforming values as needed.