### PR TITLE
Implement /logs endpoint

### DIFF
--- a/src/main/java/com/eighthlight/fabrial/http/AccessLogResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/AccessLogResponder.java
@@ -22,12 +22,22 @@ public class AccessLogResponder implements HttpResponder {
 
   @Override
   public Response getResponse(Request request) {
-    if (!request.method.equals(Method.GET)) {
+    if (request.method.equals(Method.HEAD)) {
+      return new ResponseBuilder().withVersion(request.version)
+                                  .withStatusCode(200)
+                                  .build();
+    } else if (request.method.equals(Method.OPTIONS)) {
+      return new ResponseBuilder().withVersion(request.version)
+                                  .withStatusCode(200)
+                                  .withHeader("Allow", String.join(",", Method.GET.name(), Method.HEAD.name(), Method.OPTIONS.name()))
+                                  .build();
+    } else if (!request.method.equals(Method.GET)) {
       return new ResponseBuilder()
           .withVersion(request.version)
           .withStatusCode(405)
           .build();
     }
+
     var body =
         accessLogger
             .loggedRequests()

--- a/src/main/java/com/eighthlight/fabrial/http/AccessLogResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/AccessLogResponder.java
@@ -1,0 +1,51 @@
+package com.eighthlight.fabrial.http;
+
+import com.eighthlight.fabrial.http.message.request.Request;
+import com.eighthlight.fabrial.http.message.response.Response;
+import com.eighthlight.fabrial.http.message.response.ResponseBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class AccessLogResponder implements HttpResponder {
+  private final AccessLogger accessLogger;
+
+  public AccessLogResponder(AccessLogger accessLogger) {
+    this.accessLogger = accessLogger;
+  }
+
+  @Override
+  public boolean matches(Request request) {
+    return request.uri.getPath().equals("/logs");
+  }
+
+  @Override
+  public Response getResponse(Request request) {
+    if (!request.method.equals(Method.GET)) {
+      return new ResponseBuilder()
+          .withVersion(request.version)
+          .withStatusCode(405)
+          .build();
+    }
+    var body =
+        accessLogger
+            .loggedRequests()
+            .stream()
+            .map(r -> String.join(" ",
+                                  r.method.name(),
+                                  r.uri.getPath().toString(),
+                                  r.version))
+            .collect(Collectors.joining("\n"))
+            .getBytes();
+    return new ResponseBuilder()
+        .withVersion(request.version)
+        .withStatusCode(200)
+        .withHeaders(Map.of(
+            "Content-Length", Integer.toString(body.length),
+            "Content-Type", "text/plain"
+        ))
+        .withBody(new ByteArrayInputStream(body))
+        .build();
+  }
+}

--- a/src/main/java/com/eighthlight/fabrial/http/AccessLogger.java
+++ b/src/main/java/com/eighthlight/fabrial/http/AccessLogger.java
@@ -3,16 +3,18 @@ package com.eighthlight.fabrial.http;
 import com.eighthlight.fabrial.http.message.request.Request;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class AccessLogger {
-  private final ArrayList<RequestLog> logs;
+  private final List<RequestLog> logs;
 
   public AccessLogger() {
-    this.logs = new ArrayList<>();
+    this.logs = Collections.synchronizedList(new ArrayList<>());
   }
 
   public void log(Request r) {
+    // a real access log would track when reqs were received, but that will make cob_spec upset
     logs.add(new RequestLog(r.version, r.method, r.uri, r.headers));
   }
 

--- a/src/main/java/com/eighthlight/fabrial/http/AccessLogger.java
+++ b/src/main/java/com/eighthlight/fabrial/http/AccessLogger.java
@@ -6,6 +6,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * TEMP: This is naive in that it's unbounded and memory-based, meaning that after enough requests
+ * it will cause the server to crash due to OOM. To be "production ready", this would at the very least
+ * read/write to a file instead with the `loggedRequests` method being replaced by a sort of `tail`
+ * method that returns the last N logs.
+ */
 public class AccessLogger {
   private final List<RequestLog> logs;
 

--- a/src/main/java/com/eighthlight/fabrial/http/AccessLogger.java
+++ b/src/main/java/com/eighthlight/fabrial/http/AccessLogger.java
@@ -1,0 +1,22 @@
+package com.eighthlight.fabrial.http;
+
+import com.eighthlight.fabrial.http.message.request.Request;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AccessLogger {
+  private final ArrayList<RequestLog> logs;
+
+  public AccessLogger() {
+    this.logs = new ArrayList<>();
+  }
+
+  public void log(Request r) {
+    logs.add(new RequestLog(r.version, r.method, r.uri, r.headers));
+  }
+
+  public List<RequestLog> loggedRequests() {
+    return List.copyOf(logs);
+  }
+}

--- a/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
+++ b/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
@@ -56,6 +56,7 @@ public class HttpConnectionHandler implements ConnectionHandler {
     }
 
     logger.info("Handling request {}", StructuredArguments.kv("request", request));
+    requestDelgate.accept(request);
     Response response = responseTo(request);
     logger.info("Writing response {}", StructuredArguments.kv("response", response));
     new ResponseWriter(os).writeResponse(response);

--- a/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
+++ b/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
@@ -16,7 +16,6 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
 
 public class HttpConnectionHandler implements ConnectionHandler {
@@ -25,11 +24,11 @@ public class HttpConnectionHandler implements ConnectionHandler {
   // ???: if this changes, probably need to also "match" the request version somehow?
   private static final List<String> SUPPORTED_HTTP_VERSIONS = List.of(HttpVersion.ONE_ONE);
 
-  private final Set<? extends HttpResponder> responders;
+  private final List<? extends HttpResponder> responders;
 
   private final Consumer<Request> requestDelegate;
 
-  public HttpConnectionHandler(List<HttpResponder> responders, Consumer<Request> requestDelegate) {
+  public <T extends HttpResponder> HttpConnectionHandler(List<T> responders, Consumer<Request> requestDelegate) {
     this.requestDelegate = Optional.ofNullable(requestDelegate).orElse(r -> {});
     assert !responders.isEmpty();
     this.responders = responders;

--- a/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
+++ b/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
@@ -27,10 +27,10 @@ public class HttpConnectionHandler implements ConnectionHandler {
 
   private final Set<? extends HttpResponder> responders;
 
-  private final Consumer<Request> requestDelgate;
+  private final Consumer<Request> requestDelegate;
 
-  public <T extends HttpResponder> HttpConnectionHandler(Set<T> responders, Consumer<Request> requestDelgate) {
-    this.requestDelgate = Optional.ofNullable(requestDelgate).orElse(r -> {});
+  public HttpConnectionHandler(List<HttpResponder> responders, Consumer<Request> requestDelegate) {
+    this.requestDelegate = Optional.ofNullable(requestDelegate).orElse(r -> {});
     assert !responders.isEmpty();
     this.responders = responders;
   }
@@ -56,7 +56,7 @@ public class HttpConnectionHandler implements ConnectionHandler {
     }
 
     logger.info("Handling request {}", StructuredArguments.kv("request", request));
-    requestDelgate.accept(request);
+    requestDelegate.accept(request);
     Response response = responseTo(request);
     logger.info("Writing response {}", StructuredArguments.kv("response", response));
     new ResponseWriter(os).writeResponse(response);

--- a/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
+++ b/src/main/java/com/eighthlight/fabrial/http/HttpConnectionHandler.java
@@ -28,7 +28,7 @@ public class HttpConnectionHandler implements ConnectionHandler {
 
   private final Consumer<Request> requestDelegate;
 
-  public <T extends HttpResponder> HttpConnectionHandler(List<T> responders, Consumer<Request> requestDelegate) {
+  public HttpConnectionHandler(List<? extends HttpResponder> responders, Consumer<Request> requestDelegate) {
     this.requestDelegate = Optional.ofNullable(requestDelegate).orElse(r -> {});
     assert !responders.isEmpty();
     this.responders = responders;

--- a/src/main/java/com/eighthlight/fabrial/http/RequestLog.java
+++ b/src/main/java/com/eighthlight/fabrial/http/RequestLog.java
@@ -1,0 +1,47 @@
+package com.eighthlight.fabrial.http;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+
+public class RequestLog {
+  public final String version;
+  public final Method method;
+  public final URI uri;
+  public final Map<String, String> headers;
+
+  public RequestLog(String version, Method method, URI uri, Map<String, String> headers) {
+    this.version = version;
+    this.method = method;
+    this.uri = uri;
+    this.headers = headers;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    RequestLog that = (RequestLog) o;
+    return Objects.equals(version, that.version) &&
+           method == that.method &&
+           Objects.equals(uri, that.uri) &&
+           Objects.equals(headers, that.headers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, method, uri, headers);
+  }
+
+  @Override
+  public String toString() {
+    return "RequestLog{" +
+           "version='" + version + '\'' +
+           ", method=" + method +
+           ", uri=" + uri +
+           ", headers=" + headers +
+           '}';
+  }
+}

--- a/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
+++ b/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
@@ -33,7 +33,7 @@ public class TcpServer implements Closeable {
              Set.of(
                  new FileHttpResponder(
                      new LocalFilesystemController(config.directoryPath)
-                 ))),
+                 )), null),
          new AsyncServerSocketController(config.readTimeout));
   }
 

--- a/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
+++ b/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
@@ -11,8 +11,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class TcpServer implements Closeable {
@@ -30,7 +30,7 @@ public class TcpServer implements Closeable {
   public TcpServer(ServerConfig config) {
     this(config,
          new HttpConnectionHandler(
-             Set.of(
+             List.of(
                  new FileHttpResponder(
                      new LocalFilesystemController(config.directoryPath)
                  )), null),

--- a/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
+++ b/src/main/java/com/eighthlight/fabrial/server/TcpServer.java
@@ -1,5 +1,7 @@
 package com.eighthlight.fabrial.server;
 
+import com.eighthlight.fabrial.http.AccessLogResponder;
+import com.eighthlight.fabrial.http.AccessLogger;
 import com.eighthlight.fabrial.http.HttpConnectionHandler;
 import com.eighthlight.fabrial.http.file.FileHttpResponder;
 import com.eighthlight.fabrial.http.file.LocalFilesystemController;
@@ -28,12 +30,16 @@ public class TcpServer implements Closeable {
   private final SocketController socketController;
 
   public TcpServer(ServerConfig config) {
+    this(config, new AccessLogger());
+  }
+
+  public TcpServer(ServerConfig config, AccessLogger accessLogger) {
     this(config,
          new HttpConnectionHandler(
              List.of(
-                 new FileHttpResponder(
-                     new LocalFilesystemController(config.directoryPath)
-                 )), null),
+                 new AccessLogResponder(accessLogger),
+                 new FileHttpResponder(new LocalFilesystemController(config.directoryPath))),
+             accessLogger::log),
          new AsyncServerSocketController(config.readTimeout));
   }
 

--- a/src/test/java/com/eighthlight/fabrial/test/http/AccessLogIntegrationTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/AccessLogIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.HttpVersion;
+import com.eighthlight.fabrial.http.Method;
+import com.eighthlight.fabrial.http.message.request.Request;
+import com.eighthlight.fabrial.http.message.request.RequestBuilder;
+import com.eighthlight.fabrial.server.ServerConfig;
+import com.eighthlight.fabrial.test.client.TcpClient;
+import com.eighthlight.fabrial.test.fixtures.TcpClientFixture;
+import com.eighthlight.fabrial.test.fixtures.TcpServerFixture;
+import com.eighthlight.fabrial.test.http.client.HttpClient;
+import com.eighthlight.fabrial.utils.Result;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AccessLogIntegrationTest {
+  @Test
+  void emptyLogs() throws Exception {
+    try (
+        var serverFixture = new TcpServerFixture(new ServerConfig(
+            ServerConfig.DEFAULT_PORT,
+            ServerConfig.DEFAULT_READ_TIMEOUT,
+            ServerConfig.DEFAULT_DIRECTORY_PATH
+        ));
+        var clientFixture = new TcpClientFixture(ServerConfig.DEFAULT_PORT)) {
+      serverFixture.server.start();
+      clientFixture.client.connect();
+      var client = new HttpClient(clientFixture.client);
+      var response =
+          client.send(new RequestBuilder()
+                          .withVersion(HttpVersion.ONE_ONE)
+                          .withMethod(Method.GET)
+                          .withUriString("/logs")
+                          .build())
+                .get();
+      assertThat(response.statusCode, equalTo(200));
+    }
+  }
+
+  @Test
+  void returnsPriorRequests() throws Exception {
+    try (
+        var serverFixture = new TcpServerFixture(new ServerConfig(
+            ServerConfig.DEFAULT_PORT,
+            ServerConfig.DEFAULT_READ_TIMEOUT,
+            ServerConfig.DEFAULT_DIRECTORY_PATH
+        ))) {
+      var methods = List.of(Method.GET, Method.PUT, Method.POST);
+      methods
+          .stream()
+          .map(m -> new Request(HttpVersion.ONE_ONE, m, Result.attempt(() -> new URI("/")).orElseAssert()))
+          .forEach(r -> {
+            try (var client = new HttpClient(new TcpClient(new InetSocketAddress(serverFixture.server.config.port)))) {
+              client.send(r);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          });
+
+      try (var client = new HttpClient(new TcpClient(new InetSocketAddress(serverFixture.server.config.port)))) {
+        var response =
+            client.send(new RequestBuilder()
+                            .withVersion(HttpVersion.ONE_ONE)
+                            .withUriString("/logs")
+                            .build())
+                  .get();
+        assertThat(response.statusCode, equalTo(200));
+        var bodyReader = new BufferedReader(new InputStreamReader(response.body));
+        methods.forEach(m -> {
+          var line = Result.attempt(bodyReader::readLine).orElseAssert();
+          assertThat(line, containsString(m.name()));
+        });
+      }
+    }
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/AccessLogResponderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/AccessLogResponderTest.java
@@ -8,6 +8,7 @@ import com.eighthlight.fabrial.http.message.request.RequestBuilder;
 import com.eighthlight.fabrial.utils.Result;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -18,6 +19,22 @@ import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.lists;
 
 public class AccessLogResponderTest {
+  @Test
+  void respondsWithEmptyBodyWhenLogIsEmpty() throws IOException {
+    var logger = new AccessLogger();
+    var responder = new AccessLogResponder(logger);
+
+    var response = responder.getResponse(
+        new RequestBuilder()
+            .withVersion(HttpVersion.ONE_ONE)
+            .withMethod(Method.GET)
+            .withUriString("/logs")
+            .build());
+
+    assertThat(response.statusCode, equalTo(200));
+    assertThat(response.body.readAllBytes(), equalTo(new byte[0]));
+  }
+
   @Test
   void respondsWithBodyContainingFormattedLog() {
     qt().forAll(lists().of(requests()).ofSizeBetween(1, 100))

--- a/src/test/java/com/eighthlight/fabrial/test/http/AccessLogResponderTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/AccessLogResponderTest.java
@@ -1,0 +1,51 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.AccessLogResponder;
+import com.eighthlight.fabrial.http.AccessLogger;
+import com.eighthlight.fabrial.http.HttpVersion;
+import com.eighthlight.fabrial.http.Method;
+import com.eighthlight.fabrial.http.message.request.RequestBuilder;
+import com.eighthlight.fabrial.utils.Result;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static com.eighthlight.fabrial.test.gen.ArbitraryHttp.requests;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.lists;
+
+public class AccessLogResponderTest {
+  @Test
+  void respondsWithBodyContainingFormattedLog() {
+    qt().forAll(lists().of(requests()).ofSizeBetween(1, 100))
+        .checkAssert(rs -> {
+          var logger = new AccessLogger();
+          var responder = new AccessLogResponder(logger);
+          rs.forEach(logger::log);
+
+          var response = responder.getResponse(
+              new RequestBuilder()
+                  .withVersion(HttpVersion.ONE_ONE)
+                  .withMethod(Method.GET)
+                  .withUriString("/logs")
+                  .build());
+
+          assertThat(response.statusCode, equalTo(200));
+
+          var actualBodyLines = Arrays.asList(
+              new String(Result.attempt(response.body::readAllBytes).orElseAssert()).split("\n"));
+          var expectedBodyLines =
+              rs.stream()
+                .map(r -> String.join(" ",
+                                      r.method.name(),
+                                      r.uri.getPath().toString(),
+                                      r.version))
+                .collect(Collectors.toList());
+
+          assertThat(actualBodyLines, equalTo(expectedBodyLines));
+        });
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/AppAcceptanceTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/AppAcceptanceTest.java
@@ -11,8 +11,6 @@ import com.eighthlight.fabrial.test.http.client.HttpClient;
 import com.eighthlight.fabrial.utils.Result;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerIOStreamTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerIOStreamTests.java
@@ -15,7 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Set;
+import java.util.List;
 
 import static com.eighthlight.fabrial.http.HttpConstants.CRLF;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -38,7 +38,7 @@ public class HttpConnectionHandlerIOStreamTests implements HttpResponder {
     return new ResponseBuilder().withVersion(HttpVersion.ONE_ONE).withStatusCode(200).build();
   }
 
-  HttpConnectionHandler handler = new HttpConnectionHandler(Set.of(this), null);
+  HttpConnectionHandler handler = new HttpConnectionHandler(List.of(this), null);
 
   String sendRequest(Request req) throws Throwable {
     ByteArrayOutputStream reqOs = new ByteArrayOutputStream();

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerIOStreamTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerIOStreamTests.java
@@ -38,7 +38,7 @@ public class HttpConnectionHandlerIOStreamTests implements HttpResponder {
     return new ResponseBuilder().withVersion(HttpVersion.ONE_ONE).withStatusCode(200).build();
   }
 
-  HttpConnectionHandler handler = new HttpConnectionHandler(Set.of(this));
+  HttpConnectionHandler handler = new HttpConnectionHandler(Set.of(this), null);
 
   String sendRequest(Request req) throws Throwable {
     ByteArrayOutputStream reqOs = new ByteArrayOutputStream();

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerTests.java
@@ -1,76 +1,30 @@
 package com.eighthlight.fabrial.test.http;
 
 import com.eighthlight.fabrial.http.HttpConnectionHandler;
-import com.eighthlight.fabrial.http.HttpResponder;
 import com.eighthlight.fabrial.http.HttpVersion;
-import com.eighthlight.fabrial.http.Method;
 import com.eighthlight.fabrial.http.message.request.Request;
-import com.eighthlight.fabrial.http.message.response.Response;
 import com.eighthlight.fabrial.http.message.response.ResponseBuilder;
+import com.eighthlight.fabrial.test.http.client.ResponseReader;
+import com.eighthlight.fabrial.test.http.request.RequestWriter;
+import com.eighthlight.fabrial.utils.Result;
 import org.junit.jupiter.api.Test;
 import org.quicktheories.core.Gen;
 
-import java.net.URI;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import static com.eighthlight.fabrial.test.gen.ArbitraryHttp.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.Generate.constant;
 import static org.quicktheories.generators.SourceDSL.lists;
 
 public class HttpConnectionHandlerTests {
-  public static class MockResponder implements HttpResponder {
-    public final URI targetURI;
-    public final Method targetMethod;
-    public final Response response;
-
-    public MockResponder(URI targetURI, Method targetMethod, Response response) {
-      this.targetURI = targetURI;
-      this.targetMethod = targetMethod;
-      this.response = response;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o)
-        return true;
-      if (o == null || getClass() != o.getClass())
-        return false;
-      MockResponder that = (MockResponder) o;
-      // intentionally excluding response
-      return Objects.equals(targetURI, that.targetURI) &&
-             Objects.equals(targetMethod, that.targetMethod);
-    }
-
-    @Override
-    public String toString() {
-      return "MockResponder{" +
-             "targetURI=" + targetURI +
-             ", targetMethod=" + targetMethod +
-             ", response=" + response +
-             '}';
-    }
-
-    @Override
-    public int hashCode() {
-      // intentionally excluding response
-      return Objects.hash(targetURI, targetMethod);
-    }
-
-    @Override
-    public boolean matches(Request request) {
-      return request.uri.equals(targetURI) && request.method.equals(targetMethod);
-    }
-
-    @Override
-    public Response getResponse(Request request) {
-      return response;
-    }
-  }
 
   public static Gen<MockResponder> mockResponders() {
     return methods().zip(requestTargets(), statusCodes(), (method, uri, statusCode) ->
@@ -87,17 +41,50 @@ public class HttpConnectionHandlerTests {
   }
 
   @Test
+  void passesRequestToHandler() {
+    qt().forAll(requests(methods(), requestTargets(), constant(HttpVersion.ONE_ONE)))
+        .checkAssert(r -> {
+          Result.attempt(() -> {
+            var baos = new ByteArrayOutputStream();
+            new RequestWriter(baos).writeRequest(r);
+            var serializdRequestStream = new ByteArrayInputStream(baos.toByteArray());
+
+
+            var expectedResponse = new ResponseBuilder().withVersion(HttpVersion.ONE_ONE)
+                                                        .withStatusCode(200)
+                                                        .build();
+
+            var mockResponder = new MockResponder(r.uri, r.method, expectedResponse);
+
+            var delegatedRequest = new CompletableFuture<Request>();
+
+            HttpConnectionHandler handler =
+                new HttpConnectionHandler(Set.of(mockResponder), delegatedRequest::complete);
+
+            var responseBaos = new ByteArrayOutputStream();
+            handler.handle(serializdRequestStream, responseBaos);
+
+            var actualResponse =
+                new ResponseReader(new ByteArrayInputStream(responseBaos.toByteArray())).read().get();
+            assertThat(actualResponse, equalTo(expectedResponse));
+
+//            assertThat(delegatedRequest.get(10, TimeUnit.MILLISECONDS), equalTo(r));
+          }).orElseAssert();
+        });
+  }
+
+  @Test
   void respondsWithMatchingResponder() {
     qt().forAll(mockResponderLists().map(Set::copyOf))
         .checkAssert(rs -> {
-          HttpConnectionHandler handler = new HttpConnectionHandler(rs);
-          rs.forEach(r ->
-                         assertThat(
-                             handler.responseTo(new Request(HttpVersion.ONE_ONE,
-                                                            r.targetMethod,
-                                                            r.targetURI)),
-                             equalTo(r.response)
-                         ));
+          HttpConnectionHandler handler = new HttpConnectionHandler(rs, null);
+          rs.forEach(r -> {
+            assertThat(
+                handler.responseTo(new Request(HttpVersion.ONE_ONE,
+                                               r.targetMethod,
+                                               r.targetURI)),
+                equalTo(r.response));
+          });
         });
   }
 
@@ -108,7 +95,7 @@ public class HttpConnectionHandlerTests {
                       responders.stream().noneMatch(r -> r.matches(req))
         )
         .checkAssert((rs, req) -> {
-          HttpConnectionHandler handler = new HttpConnectionHandler(rs);
+          HttpConnectionHandler handler = new HttpConnectionHandler(rs, null);
           assertThat(handler.responseTo(req),
                      equalTo(new ResponseBuilder().withVersion(HttpVersion.ONE_ONE).withStatusCode(404).build()));
         });
@@ -116,6 +103,6 @@ public class HttpConnectionHandlerTests {
 
   @Test
   void throwsWhenRespondersEmpty() {
-    assertThrows(AssertionError.class, () -> new HttpConnectionHandler(Set.of()));
+    assertThrows(AssertionError.class, () -> new HttpConnectionHandler(Set.of(), null));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerTests.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/HttpConnectionHandlerTests.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static com.eighthlight.fabrial.test.gen.ArbitraryHttp.*;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -68,7 +69,7 @@ public class HttpConnectionHandlerTests {
                 new ResponseReader(new ByteArrayInputStream(responseBaos.toByteArray())).read().get();
             assertThat(actualResponse, equalTo(expectedResponse));
 
-//            assertThat(delegatedRequest.get(10, TimeUnit.MILLISECONDS), equalTo(r));
+            assertThat(delegatedRequest.get(10, TimeUnit.MILLISECONDS), equalTo(r));
           }).orElseAssert();
         });
   }

--- a/src/test/java/com/eighthlight/fabrial/test/http/MockResponder.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/MockResponder.java
@@ -1,0 +1,58 @@
+package com.eighthlight.fabrial.test.http;
+
+import com.eighthlight.fabrial.http.HttpResponder;
+import com.eighthlight.fabrial.http.Method;
+import com.eighthlight.fabrial.http.message.request.Request;
+import com.eighthlight.fabrial.http.message.response.Response;
+
+import java.net.URI;
+import java.util.Objects;
+
+public class MockResponder implements HttpResponder {
+  public final URI targetURI;
+  public final Method targetMethod;
+  public final Response response;
+
+  public MockResponder(URI targetURI, Method targetMethod, Response response) {
+    this.targetURI = targetURI;
+    this.targetMethod = targetMethod;
+    this.response = response;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    MockResponder that = (MockResponder) o;
+    // intentionally excluding response
+    return Objects.equals(targetURI, that.targetURI) &&
+           Objects.equals(targetMethod, that.targetMethod);
+  }
+
+  @Override
+  public String toString() {
+    return "MockResponder{" +
+           "targetURI=" + targetURI +
+           ", targetMethod=" + targetMethod +
+           ", response=" + response +
+           '}';
+  }
+
+  @Override
+  public int hashCode() {
+    // intentionally excluding response
+    return Objects.hash(targetURI, targetMethod);
+  }
+
+  @Override
+  public boolean matches(Request request) {
+    return request.uri.equals(targetURI) && request.method.equals(targetMethod);
+  }
+
+  @Override
+  public Response getResponse(Request request) {
+    return response;
+  }
+}

--- a/src/test/java/com/eighthlight/fabrial/test/http/client/HttpClient.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/client/HttpClient.java
@@ -9,7 +9,7 @@ import com.eighthlight.fabrial.test.http.request.RequestWriter;
 import java.io.IOException;
 import java.util.Optional;
 
-public class HttpClient {
+public class HttpClient implements AutoCloseable {
   private final TcpClient client;
 
   public HttpClient(TcpClient client) {
@@ -19,5 +19,10 @@ public class HttpClient {
   public Optional<Response> send(Request request) throws IOException, MessageReaderException {
     new RequestWriter(client.getOutputStream()).writeRequest(request);
     return new ResponseReader(client.getInputStream()).read();
+  }
+
+  @Override
+  public void close() throws Exception {
+    client.close();
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/server/AccessLoggerTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/server/AccessLoggerTest.java
@@ -1,0 +1,40 @@
+package com.eighthlight.fabrial.test.server;
+
+import com.eighthlight.fabrial.http.AccessLogger;
+import com.eighthlight.fabrial.http.HttpVersion;
+import com.eighthlight.fabrial.http.Method;
+import com.eighthlight.fabrial.http.RequestLog;
+import com.eighthlight.fabrial.http.message.request.Request;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AccessLoggerTest {
+  @Test
+  void noLogsForNoRequests() {
+    assertThat(new AccessLogger().loggedRequests(), equalTo(List.of()));
+  }
+
+  @Test
+  void returnsLoggedRequests() throws Exception {
+    var accessLogger = new AccessLogger();
+    var requests = List.of(
+        new Request(HttpVersion.ONE_ONE, Method.GET, new URI("/")),
+        new Request(HttpVersion.TWO_ZERO,
+                    Method.PUT,
+                    new URI("/foo"),
+                    Map.of("foo", "bar"),
+                    null));
+    requests.forEach(accessLogger::log);
+    assertThat(accessLogger.loggedRequests(),
+               equalTo(requests.stream()
+                               .map(r -> new RequestLog(r.version, r.method, r.uri, r.headers))
+                               .collect(Collectors.toList())));
+  }
+}


### PR DESCRIPTION
> Resolves #55

Add a `/logs` endpoint which returns a list of newline-separated requests in the format:

```
method uri-path http-version
```

Required implementing a (thread safe) access log data structure, wrapping it in a responder, and refactoring `HttpConnectionHandler` to respond with the first matching responder in the list (whereas before there were no guarantees about which matching responder would be used).