### PR TITLE
Fix byte range bugs

### DIFF
--- a/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
+++ b/src/main/java/com/eighthlight/fabrial/http/file/FileHttpResponder.java
@@ -131,7 +131,7 @@ public class FileHttpResponder implements HttpResponder {
           } catch (HttpRequestByteRange.ParsingException e) {
             // return early with unsatisfiable range response
             return builder.withStatusCode(416)
-                          .withHeader("Content-Range", "*/" + sizeInt)
+                          .withHeader("Content-Range", "bytes */" + sizeInt)
                           .withReason(e.getMessage())
                           .build();
           }

--- a/src/test/java/com/eighthlight/fabrial/test/gen/ArbitraryByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/gen/ArbitraryByteRangeTest.java
@@ -81,18 +81,15 @@ public class ArbitraryByteRangeTest {
 
   @Test
   void parsesRangesWithValidLastPosition() {
-    qt().forAll(fileSizeAndPosition())
-        .assuming(p -> p._2 > 0)
-        .checkAssert(p -> {
-          var size = p._1;
-          var suffixLength = p._2;
+    qt().forAll(integers().allPositive(), integers().allPositive())
+        .checkAssert((size, suffixLength) -> {
           var rangeHeader = String.format("bytes=-%d", suffixLength);
           var range = Result
               .attempt(() -> HttpRequestByteRange.parseFromHeader(rangeHeader, size))
               .orElseAssert();
-          assertThat(range.first, is(size - suffixLength));
+          assertThat(range.first, is(Integer.max(0, size-suffixLength)));
           assertThat(range.last, is(size - 1));
-          assertThat(range.length(), is(suffixLength));
+          assertThat(range.length(), is(Integer.min(suffixLength, size)));
         });
   }
 

--- a/src/test/java/com/eighthlight/fabrial/test/http/request/HttpRequestByteRangeTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/request/HttpRequestByteRangeTest.java
@@ -51,6 +51,12 @@ public class HttpRequestByteRangeTest {
   }
 
   @Test
+  void failsToParseFirstIndexGreaterThanLastIndexWithLargerFile() {
+    assertThrows(HttpRequestByteRange.ParsingException.class,
+                 () -> HttpRequestByteRange.parseFromHeader("bytes=1-0", 2));
+  }
+
+  @Test
   void failsToParseEmptySuffixRange() {
     assertThrows(HttpRequestByteRange.ParsingException.class,
                  () -> HttpRequestByteRange.parseFromHeader("-0", 1));
@@ -110,6 +116,14 @@ public class HttpRequestByteRangeTest {
   @Test
   void wrapsRangesToFileLength() throws HttpRequestByteRange.ParsingException {
     var range = HttpRequestByteRange.parseFromHeader("bytes=0-5", 2);
+    assertThat(range.first, is(0));
+    assertThat(range.last, is(1));
+    assertThat(range.length(), is(2));
+  }
+
+  @Test
+  void wrapsSuffixRangesToFileLength() throws HttpRequestByteRange.ParsingException {
+    var range = HttpRequestByteRange.parseFromHeader("bytes=-5", 2);
     assertThat(range.first, is(0));
     assertThat(range.last, is(1));
     assertThat(range.length(), is(2));

--- a/src/test/java/com/eighthlight/fabrial/test/http/responder/FileHttpResponderGetTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/responder/FileHttpResponderGetTest.java
@@ -141,6 +141,6 @@ public class FileHttpResponderGetTest {
             .build());
     assertThat(response.statusCode, is(416));
     assertThat(response.reason, containsString("Last position cannot be less than the first"));
-    assertThat(response.headers, hasEntry("Content-Range", "*/" + child.data.length));
+    assertThat(response.headers, hasEntry("Content-Range", "bytes */" + child.data.length));
   }
 }

--- a/src/test/java/com/eighthlight/fabrial/test/http/responder/FileHttpResponderGetTest.java
+++ b/src/test/java/com/eighthlight/fabrial/test/http/responder/FileHttpResponderGetTest.java
@@ -166,7 +166,7 @@ public class FileHttpResponderGetTest {
     assertThat(response.statusCode, is(206));
     assertThat(response.headers, hasEntry("Content-Length", Integer.toString(child.data.length)));
     assertThat(response.headers, hasEntry("Content-Type", child.type));
-    assertThat(response.headers, hasEntry("Content-Range", "bytes 0-" + (child.data.length - 2) + "/" + child.data.length));
+    assertThat(response.headers, hasEntry("Content-Range", "bytes 0-" + (child.data.length - 1) + "/" + child.data.length));
     assertThat(response.body, is(not(nullValue())));
     assertThat(new String(response.body.readAllBytes()),
                is(new String(child.data)));


### PR DESCRIPTION
- Suffix range requests weren't wrapped properly
- Unsatisfiable range responses' `Content-Range` header wasn't formatted properly